### PR TITLE
workspaceディレクトリの所有者をvscodeユーザーに変更

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p /workspaces && chown vscode:vscode /workspaces
+
 USER vscode
 
 RUN mkdir -p $CLAUDE_CONFIG_DIR && chmod 700 $CLAUDE_CONFIG_DIR


### PR DESCRIPTION
## 概要
git worktreeを使用してworkspaceディレクトリ配下に作業ディレクトリを作成する際、workspaceディレクトリの所有者がrootだったため、ディレクトリを作成できない問題がありました。この問題を解決するため、Dockerfileでworkspaceディレクトリを事前に作成し、所有者をvscodeユーザーに変更するようにしました。

## 修正内容
- `.devcontainer/Dockerfile` に `/workspaces` ディレクトリの作成と所有者変更処理を追加
  - `mkdir -p /workspaces` でディレクトリを作成
  - `chown vscode:vscode /workspaces` で所有者をvscodeユーザーに変更

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境の設定ファイルを更新し、ワークスペースディレクトリの権限設定を修正しました。これにより、開発環境がより安定して動作するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->