### PR TITLE
assign-to-claudeラベル付きIssueを監視・自動処理するスクリプトを追加

### DIFF
--- a/.claude/scripts/watch-issue.sh
+++ b/.claude/scripts/watch-issue.sh
@@ -24,7 +24,7 @@ for issue_number in $issues; do
   trap "gh issue edit \"$issue_number\" --remove-label \"in-progress-by-claude\" || true" ERR
 
   # claudeコマンドを実行
-  claude -p "/solve-issue $issue_number"
+  claude --add-dir /workspaces -p "/solve-issue $issue_number"
 
   # トラップを解除
   trap - ERR


### PR DESCRIPTION
## 概要
`assign-to-claude`ラベルが付いたGitHub Issueを監視し、Claudeで自動的に処理するシェルスクリプトを追加しました。

## 関連Issue
Fixes: #8

## 修正内容
- `.claude/scripts/watch-issue.sh` を新規作成
- `assign-to-claude`ラベル付き、かつ`in-progress-by-claude`ラベルが付いていないissueを取得
- 対象issueに`in-progress-by-claude`ラベルを付与
- `claude --add-dir /workspaces -p "/solve-issue {issue番号}"`を実行してissueを自動処理
- エラー時には`in-progress-by-claude`ラベルを自動削除（トラップによる実装）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 内部プロセスの自動化スクリプトを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->