### PR TITLE
notify-host.shにjqコマンドの存在確認を追加

### DIFF
--- a/.claude/hooks/notify-host.sh
+++ b/.claude/hooks/notify-host.sh
@@ -4,5 +4,10 @@ if [ -z "$WORKSPACE_DIR" ]; then
   exit 1
 fi
 
+if ! command -v jq &> /dev/null; then
+  echo "[ERROR] jq が見つかりません。jq をインストールしてください。"
+  exit 1
+fi
+
 jq -n --arg msg "${1:-Done}" --arg title "${2:-Dev Container}" \
   '{message: $msg, title: $title}' > "${WORKSPACE_DIR}/.devcontainer/host-notifier.json"


### PR DESCRIPTION
## 概要
`.claude/hooks/notify-host.sh` にjqコマンドの存在確認を追加し、jqがインストールされていない環境でも明確なエラーメッセージが表示されるようにしました。

## 関連Issue
Fixes #5

## 修正内容
- `command -v jq &> /dev/null` でjqコマンドの存在を確認
- jqが見つからない場合は `[ERROR]` メッセージを表示して `exit 1`
- `install-gh.sh` と同様の実装パターンに統一

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 必須コマンドの環境確認機能を追加し、見つからない場合は明確なエラーメッセージを表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->