### PR TITLE
GitHub ActionsでGoのビルドと自動テストを実装

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: build
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: app/go.mod
+
+      - name: Setup
+        run: make setup
+
+      - name: Format check
+        run: make fmt-check
+
+      - name: Lint
+        run: make lint
+
+      - name: Test
+        run: make test
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage
+          path: app/coverage.out
+          retention-days: 7
+
+      - name: Build
+        run: make build

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,0 +1,19 @@
+.PHONY: setup
+setup:
+	go mod download
+
+.PHONY: fmt-check
+fmt-check:
+	test -z "$$(gofmt -l .)"
+
+.PHONY: lint
+lint:
+	go vet ./...
+
+.PHONY: test
+test:
+	go test -v -race -coverprofile=coverage.out ./...
+
+.PHONY: build
+build:
+	go build -v ./...

--- a/app/generator_test.go
+++ b/app/generator_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestMockDiaryGenerator_GenerateDiary(t *testing.T) {
+	generator := &MockDiaryGenerator{}
+
+	content, err := generator.GenerateDiary("/path/to/image.jpg")
+	if err != nil {
+		t.Fatalf("GenerateDiary failed: %v", err)
+	}
+
+	if content == "" {
+		t.Error("expected non-empty content, got empty string")
+	}
+
+	// モック実装は固定の文字列を返すことを確認
+	expected := "この植物は順調に成長しています。葉の色が鮮やかで、新しい芽も見られます。"
+	if content != expected {
+		t.Errorf("expected content '%s', got '%s'", expected, content)
+	}
+}

--- a/app/repository_test.go
+++ b/app/repository_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMockDiaryRepository_CreateDiary(t *testing.T) {
+	repo := NewMockDiaryRepository()
+
+	err := repo.CreateDiary("/path/to/image.jpg", "テスト日記")
+	if err != nil {
+		t.Fatalf("CreateDiary failed: %v", err)
+	}
+
+	diaries, err := repo.GetAllDiaries()
+	if err != nil {
+		t.Fatalf("GetAllDiaries failed: %v", err)
+	}
+
+	if len(diaries) != 1 {
+		t.Errorf("expected 1 diary, got %d", len(diaries))
+	}
+
+	if diaries[0].ImagePath != "/path/to/image.jpg" {
+		t.Errorf("expected ImagePath '/path/to/image.jpg', got '%s'", diaries[0].ImagePath)
+	}
+
+	if diaries[0].Content != "テスト日記" {
+		t.Errorf("expected Content 'テスト日記', got '%s'", diaries[0].Content)
+	}
+}
+
+func TestMockDiaryRepository_GetDiaryByID(t *testing.T) {
+	repo := NewMockDiaryRepository()
+
+	err := repo.CreateDiary("/path/to/image.jpg", "テスト日記")
+	if err != nil {
+		t.Fatalf("CreateDiary failed: %v", err)
+	}
+
+	diary, err := repo.GetDiaryByID(1)
+	if err != nil {
+		t.Fatalf("GetDiaryByID failed: %v", err)
+	}
+
+	if diary == nil {
+		t.Fatal("expected diary, got nil")
+	}
+
+	if diary.ID != 1 {
+		t.Errorf("expected ID 1, got %d", diary.ID)
+	}
+
+	// 存在しないIDを取得
+	diary, err = repo.GetDiaryByID(999)
+	if err != nil {
+		t.Fatalf("GetDiaryByID failed: %v", err)
+	}
+
+	if diary != nil {
+		t.Errorf("expected nil for non-existent ID, got %v", diary)
+	}
+}
+
+func TestMockDiaryRepository_GetAllDiaries_Order(t *testing.T) {
+	repo := NewMockDiaryRepository()
+
+	// 複数の日記を作成（時間をずらす）
+	err := repo.CreateDiary("/path/1.jpg", "日記1")
+	if err != nil {
+		t.Fatalf("CreateDiary failed: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	err = repo.CreateDiary("/path/2.jpg", "日記2")
+	if err != nil {
+		t.Fatalf("CreateDiary failed: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	err = repo.CreateDiary("/path/3.jpg", "日記3")
+	if err != nil {
+		t.Fatalf("CreateDiary failed: %v", err)
+	}
+
+	diaries, err := repo.GetAllDiaries()
+	if err != nil {
+		t.Fatalf("GetAllDiaries failed: %v", err)
+	}
+
+	if len(diaries) != 3 {
+		t.Errorf("expected 3 diaries, got %d", len(diaries))
+	}
+
+	// 新着順（CreatedAt降順）であることを確認
+	if diaries[0].Content != "日記3" {
+		t.Errorf("expected first diary to be '日記3', got '%s'", diaries[0].Content)
+	}
+
+	if diaries[2].Content != "日記1" {
+		t.Errorf("expected last diary to be '日記1', got '%s'", diaries[2].Content)
+	}
+}
+
+func TestMockDiaryRepository_IsImageProcessed(t *testing.T) {
+	repo := NewMockDiaryRepository()
+
+	// 未処理の画像
+	processed, err := repo.IsImageProcessed("/path/to/new.jpg")
+	if err != nil {
+		t.Fatalf("IsImageProcessed failed: %v", err)
+	}
+
+	if processed {
+		t.Error("expected false for unprocessed image, got true")
+	}
+
+	// 画像を処理
+	err = repo.CreateDiary("/path/to/new.jpg", "新しい日記")
+	if err != nil {
+		t.Fatalf("CreateDiary failed: %v", err)
+	}
+
+	// 処理済みの画像
+	processed, err = repo.IsImageProcessed("/path/to/new.jpg")
+	if err != nil {
+		t.Fatalf("IsImageProcessed failed: %v", err)
+	}
+
+	if !processed {
+		t.Error("expected true for processed image, got false")
+	}
+}


### PR DESCRIPTION
## 概要
プッシュされるたびにGoのビルドと自動テストを実行するGitHub Actionsワークフローを実装しました。これにより、コードの品質を保証し、リグレッションを防ぐCI/CD環境が整います。

## 関連Issue
Fixes: #19

## 修正内容
- `app/Makefile` を追加
  - `setup`: 依存関係のダウンロード
  - `fmt-check`: コードフォーマットのチェック
  - `lint`: `go vet` による静的解析
  - `test`: テスト実行とカバレッジ計測
  - `build`: ビルド実行
- `.github/workflows/build.yml` を追加
  - プッシュ時の自動ビルド・テスト実行
  - カバレッジレポートのアーティファクト保存
  - 並行処理管理（同一ref実行を1つに制限）
- `app/repository_test.go` を追加
  - `MockDiaryRepository` の各メソッドのテスト
  - 日記の作成、取得、ソート順、画像処理状態の検証
- `app/generator_test.go` を追加
  - `MockDiaryGenerator` のテスト

## その他
- テストカバレッジ: 46.3%
- 全テストが成功することを確認済み
- 参考リポジトリ: https://github.com/canpok1/ai-feed

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 複数の単体テストを追加し、テストカバレッジを拡張しました。

* **Chores**
  * 自動ビルドおよびテストパイプラインを実装しました。
  * 開発タスク自動化のための構成を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->