### PR TITLE
.gitignoreにLinuxのGoビルド成果物を除外するパターンを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.so
 *.dylib
 
+# Go build binaries (Linux)
+/app/plant-diary
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
## 概要

LinuxのGoビルド成果物（`/app/plant-diary`）が `.gitignore` で除外されていなかったため、ビルド後に未コミット変更として検出される問題を修正しました。

## 関連Issue

Fixes: #25

## 修正内容

- `.gitignore` に `/app/plant-diary` を追加
- Windows（`*.exe`）、macOS（`*.dylib`）と同様に、Linuxの実行ファイルも除外されるようになりました

## その他

この修正により、以下の効果が期待されます：
- ビルド成果物が自動的に除外され、git statusがクリーンに保たれる
- worktree削除時のエラーが発生しなくなる
- 誤ってビルド成果物をコミットするリスクが低減される

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * プロジェクト設定ファイルを更新しました。

---

**注記**: このリリースでは、エンドユーザーに直接的な影響を与える変更はありません。これは開発環境の構成に関する内部的な更新です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->