### PR TITLE
撮影スクリプトに追加オプション引数対応を実装

### DIFF
--- a/scripts/capture.sh
+++ b/scripts/capture.sh
@@ -17,7 +17,7 @@ JPEG_QUALITY="95"
 DELAY="1"  # カメラ安定のための遅延（秒）
 
 # 追加オプション（引数から取得）
-EXTRA_OPTIONS="$@"
+EXTRA_OPTIONS=("$@")
 
 # === 関数 ===
 log_message() {
@@ -44,7 +44,7 @@ DATE=$(date +%Y%m%d_%H%M)
 OUTPUT="${DATA_DIR}/${DATE}.jpg"
 
 # 撮影（追加オプション付き）
-if fswebcam -r "${RESOLUTION}" --jpeg "${JPEG_QUALITY}" -D "${DELAY}" --no-banner $EXTRA_OPTIONS "${OUTPUT}" 2>> "${LOG_FILE}"; then
+if fswebcam -r "${RESOLUTION}" --jpeg "${JPEG_QUALITY}" -D "${DELAY}" --no-banner "${EXTRA_OPTIONS[@]}" "${OUTPUT}" 2>> "${LOG_FILE}"; then
     log_message "INFO: Captured ${OUTPUT}"
     echo "撮影成功: ${OUTPUT}"
 else


### PR DESCRIPTION
## 概要

fswebcamの追加パラメータ（明るさ、回転、反転など）を実行時に指定できるよう、`scripts/capture.sh`を修正しました。

基本設定（解像度、JPEG品質、遅延時間）は固定のまま、カメラ固有のオプションのみを引数で渡せるようにすることで、環境やカメラに応じた柔軟な設定が可能になります。

## 修正内容

- `scripts/capture.sh`に引数処理を追加
  - `EXTRA_OPTIONS="$@"` で引数を取得
  - fswebcamコマンドに `$EXTRA_OPTIONS` を展開して渡す
- 基本パラメータ（解像度、JPEG品質、遅延時間）は固定値として保持
- 後方互換性を維持（引数なしでも従来通り動作）

## 使用例

```bash
# デフォルト設定で撮影
./scripts/capture.sh

# 明るさを調整
./scripts/capture.sh --set brightness=70

# 画像を90度回転
./scripts/capture.sh --rotate 90

# 複数の設定を組み合わせ
./scripts/capture.sh --set brightness=60 --rotate 180 --flip v
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * カメラ撮影スクリプトが実行時引数の追加オプションを受け取れるようになりました。ユーザーがカスタムオプションを指定して撮影コマンドに反映させることで、より柔軟なキャプチャ設定が可能になります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->