### PR TITLE
データベース接続のライフサイクル管理を修正

### DIFF
--- a/app/db.go
+++ b/app/db.go
@@ -61,15 +61,9 @@ func runMigrations(db *sql.DB, migrationsPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create migrate instance: %w", err)
 	}
-	defer func() {
-		srcErr, dbErr := m.Close()
-		if srcErr != nil {
-			log.Printf("WARN: failed to close migration source: %v", srcErr)
-		}
-		if dbErr != nil {
-			log.Printf("WARN: failed to close migration db: %v", dbErr)
-		}
-	}()
+	// Note: WithInstanceを使用した場合、データベース接続は呼び出し側が管理する。
+	// m.Close()を呼び出すとデータベース接続が閉じられる可能性があるため、呼び出さない。
+	// マイグレーションは起動時に1回だけ実行されるため、ソースを閉じなくても問題ない。
 
 	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
 		return fmt.Errorf("migration failed: %w", err)

--- a/app/worker.go
+++ b/app/worker.go
@@ -27,9 +27,10 @@ func NewWorker(repo DiaryRepository, generator DiaryGenerator, photosDir string)
 }
 
 // Start は1分ごとにポーリングするGoroutineを起動する。
-// contextがキャンセルされると停止する。
-func (w *Worker) Start(ctx context.Context) {
+// contextがキャンセルされると停止し、doneチャネルを閉じる。
+func (w *Worker) Start(ctx context.Context, done chan struct{}) {
 	go func() {
+		defer close(done)
 		ticker := time.NewTicker(1 * time.Minute)
 		defer ticker.Stop()
 


### PR DESCRIPTION
## 概要
appディレクトリで`go run ./...`を実行すると、起動直後に「ERROR: failed to check image status: sql: database is closed」エラーが発生していました。この問題を修正しました。

## 修正内容
- **app/db.go**: マイグレーション後に`m.Close()`を呼び出さないよう修正
  - `migrate.NewWithDatabaseInstance`でsqlite3.WithInstanceを使用した場合、データベース接続の管理は呼び出し側の責任
  - `m.Close()`を呼び出すとデータベース接続が閉じられる問題を解消
- **app/worker.go**: `Start()`メソッドに`done`チャネルを追加
  - goroutine停止時に通知できるようにし、安全なシャットダウンを実現
- **app/main.go**: workerの停止を待機してからデータベースを閉じるよう修正
  - 最大10秒間workerの停止を待機
  - データベースが閉じられる前にworkerが確実に停止するよう保証

## その他
動作確認済み:
- ビルド成功 ✓
- テスト全件パス ✓
- サーバー起動時のエラー解消 ✓
- 正常なシャットダウンシーケンス完了 ✓

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善内容

* **バグ修正**
  * アプリケーション終了時のワーカープロセスの適切な完了を待つようにしました。これにより、シャットダウン時により信頼性の高い終了フローが実現されます。最大10秒のタイムアウト後、HTTPサーバーは安全に停止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->