### PR TITLE
Worker画像処理順序を改善

### DIFF
--- a/app/db.go
+++ b/app/db.go
@@ -135,3 +135,16 @@ func (r *SQLiteDiaryRepository) IsImageProcessed(imagePath string) (bool, error)
 	}
 	return exists, nil
 }
+
+// GetLatestDiaryCreatedAt は最新の日記の作成日時を返す。日記が存在しない場合はゼロ値を返す
+func (r *SQLiteDiaryRepository) GetLatestDiaryCreatedAt() (time.Time, error) {
+	var createdAt time.Time
+	err := r.db.QueryRow("SELECT created_at FROM diary ORDER BY created_at DESC LIMIT 1").Scan(&createdAt)
+	if err == sql.ErrNoRows {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, err
+	}
+	return createdAt, nil
+}

--- a/app/db_test.go
+++ b/app/db_test.go
@@ -244,3 +244,49 @@ func TestSQLiteDiaryRepository_CreateDiary_CustomCreatedAt(t *testing.T) {
 		t.Errorf("expected CreatedAt %v, got %v", customTime, diaries[0].CreatedAt)
 	}
 }
+
+func TestSQLiteDiaryRepository_GetLatestDiaryCreatedAt(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewSQLiteDiaryRepository(db)
+
+	// 日記が存在しない場合はゼロ値を返す
+	latest, err := repo.GetLatestDiaryCreatedAt()
+	if err != nil {
+		t.Fatalf("GetLatestDiaryCreatedAt failed: %v", err)
+	}
+
+	if !latest.IsZero() {
+		t.Errorf("expected zero time for empty diary, got %v", latest)
+	}
+
+	// 複数の日記を作成
+	time1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	time2 := time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC)
+	time3 := time.Date(2026, 1, 3, 10, 0, 0, 0, time.UTC)
+
+	err = repo.CreateDiary("/path/1.jpg", "日記1", time1)
+	if err != nil {
+		t.Fatalf("CreateDiary failed: %v", err)
+	}
+
+	err = repo.CreateDiary("/path/2.jpg", "日記2", time2)
+	if err != nil {
+		t.Fatalf("CreateDiary failed: %v", err)
+	}
+
+	err = repo.CreateDiary("/path/3.jpg", "日記3", time3)
+	if err != nil {
+		t.Fatalf("CreateDiary failed: %v", err)
+	}
+
+	// 最新の日記の日時を取得
+	latest, err = repo.GetLatestDiaryCreatedAt()
+	if err != nil {
+		t.Fatalf("GetLatestDiaryCreatedAt failed: %v", err)
+	}
+
+	// 最新の日時（time3）と一致することを確認
+	if !latest.Equal(time3) {
+		t.Errorf("expected latest time %v, got %v", time3, latest)
+	}
+}

--- a/app/repository.go
+++ b/app/repository.go
@@ -19,6 +19,7 @@ type DiaryRepository interface {
 	GetDiaryByID(id int) (*Diary, error)
 	CreateDiary(imagePath, content string, createdAt time.Time) error
 	IsImageProcessed(imagePath string) (bool, error)
+	GetLatestDiaryCreatedAt() (time.Time, error)
 }
 
 // MockDiaryRepository はメモリ上でデータを保持するモック実装
@@ -101,4 +102,23 @@ func (r *MockDiaryRepository) IsImageProcessed(imagePath string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// GetLatestDiaryCreatedAt は最新の日記の作成日時を返す。日記が存在しない場合はゼロ値を返す
+func (r *MockDiaryRepository) GetLatestDiaryCreatedAt() (time.Time, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if len(r.diaries) == 0 {
+		return time.Time{}, nil
+	}
+
+	var latest time.Time
+	for _, d := range r.diaries {
+		if d.CreatedAt.After(latest) {
+			latest = d.CreatedAt
+		}
+	}
+
+	return latest, nil
 }


### PR DESCRIPTION
## 概要

Worker画像処理順序を改善し、日記を時系列順に自然に作成できるようにしました。これにより、最新の日記の日付より新しい画像のみを対象にし、最も古いものから順に処理されます。

## 関連Issue

Fixes: #44

## 修正内容

- `GetLatestDiaryCreatedAt()` メソッドを追加
  - `DiaryRepository` インターフェースに追加
  - `SQLiteDiaryRepository` に実装（`ORDER BY created_at DESC LIMIT 1` を使用）
  - `MockDiaryRepository` に実装
- `processNewImages()` を改修
  - 最新日記の日付を取得
  - ファイル名から日付をパースし、最新日記より新しい画像のみをフィルタリング
  - 日付順（昇順）にソート
  - 古い画像から順に処理
- テストを追加
  - `TestSQLiteDiaryRepository_GetLatestDiaryCreatedAt`
  - 日記が存在しない場合と存在する場合の両方をテスト

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 画像処理時に最新の日記作成時刻を基準にしてフィルタリング機能を追加しました。未処理の新しい画像のみを処理対象とするよう改善されました。

* **Tests**
  * 新しいフィルタリング機能に対応したテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->