### PR TITLE
GitHub ActionsでDockerイメージをGHCRにプッシュする機能を追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,34 @@ jobs:
 
       - name: Build
         run: make build
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: build  # buildジョブが成功した後に実行
+    if: github.ref == 'refs/heads/main'  # mainブランチのみ実行
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/server:latest
+            ghcr.io/${{ github.repository }}/server:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   plant-diary:
-    build: .
+    image: ghcr.io/canpok1/plant-diary/server:latest
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## 概要

mainブランチへのマージ時に、自動的にDockerイメージをビルドしてGitHub Container Registry (GHCR)に公開する機能を追加しました。これにより、`docker-compose up`で最新のビルド済みイメージを使用できるようになり、ローカルビルドの手間を削減できます。

## 修正内容

- **build.ymlにdocker-buildジョブを追加**
  - mainブランチのみで実行（`if: github.ref == 'refs/heads/main'`）
  - buildジョブ（品質チェック）が成功した後に実行（`needs: build`）
  - GHCRに2つのタグでプッシュ（`latest`とコミットSHA）
  - GitHub Actionsキャッシュでビルド高速化

- **docker-compose.ymlをGHCRイメージ指定に変更**
  - `build: .` → `image: ghcr.io/canpok1/plant-diary/server:latest`
  - GHCRから最新イメージを取得する設定に変更

## その他

- 初回はGHCRでイメージがプライベートとして作成されます
- パブリックにする場合は、GHCR設定でVisibilityを変更してください
- プライベートの場合、ローカルで`docker login ghcr.io`が必要です

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**Chores**
- CI/CDパイプラインを強化し、mainブランチへのマージ後にコンテナイメージの自動構築と配布を実装しました。
- デプロイメント構成をローカルビルドから事前構築イメージの参照に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->