### PR TITLE
日記の日付表示に曜日を追加する

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -35,6 +35,10 @@ func NewServer(repo DiaryRepository, photosDir string) (*Server, error) {
 			jst := time.FixedZone("Asia/Tokyo", 9*60*60)
 			return t.In(jst)
 		},
+		"weekdayJP": func(t time.Time) string {
+			weekdays := []string{"日", "月", "火", "水", "木", "金", "土"}
+			return weekdays[t.Weekday()]
+		},
 	}
 
 	// テンプレートディレクトリの自動検出

--- a/app/templates/detail.html
+++ b/app/templates/detail.html
@@ -99,7 +99,7 @@
     <a class="back-link" href="/">&larr; 一覧へ戻る</a>
     <main class="detail-container">
         <img class="detail-image" src="/photos/{{.Diary.ImagePath}}" alt="植物の写真">
-        <p class="detail-meta">{{(.Diary.CreatedAt | toJST).Format "2006年1月2日 15:04"}}</p>
+        <p class="detail-meta">{{(.Diary.CreatedAt | toJST).Format "2006年1月2日"}}（{{.Diary.CreatedAt | toJST | weekdayJP}}）{{(.Diary.CreatedAt | toJST).Format "15:04"}}</p>
         <div class="detail-content">{{.Diary.Content}}</div>
     </main>
 </body>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -132,7 +132,7 @@
             <div class="diary-card">
                 <img src="/photos/{{.ImagePath}}" alt="植物の写真">
                 <div class="diary-card-body">
-                    <p class="diary-card-date">{{(.CreatedAt | toJST).Format "2006年1月2日 15:04"}}</p>
+                    <p class="diary-card-date">{{(.CreatedAt | toJST).Format "2006年1月2日"}}（{{.CreatedAt | toJST | weekdayJP}}）{{(.CreatedAt | toJST).Format "15:04"}}</p>
                     <p class="diary-card-text">{{truncate .Content 50}}</p>
                     <a class="diary-card-link" href="/diary/{{.ID}}">詳細を見る &rarr;</a>
                 </div>


### PR DESCRIPTION
## 概要

日記の日付表示に日本語の曜日を追加します。

## 変更内容

- `app/server.go`: カスタムテンプレート関数 `weekdayJP` を追加（日本語曜日名を返す）
- `app/templates/index.html`: 日記一覧カードの日付表示に曜日を追加
- `app/templates/detail.html`: 日記詳細ページの日付表示に曜日を追加

## 表示例

変更前: `2026年2月21日 14:30`
変更後: `2026年2月21日（土）14:30`

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 日付表示に日本語の曜日を追加しました。詳細ページと一覧ページで、日付、曜日、時間がより明確に区切られて表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->