### PR TITLE
`docker compose up -d` でイメージを常にpullするように設定する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   plant-diary:
     image: ghcr.io/canpok1/plant-diary/server:latest
+    pull_policy: always
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## 概要

`docker compose up -d` 実行時、デフォルトではローカルにイメージが存在する場合はpullをスキップする。
`latest` タグを使用している場合、リモートに新しいイメージがあってもローカルの古いイメージが使われ続けるリスクがある。

`pull_policy: always` を追加することで、常に最新のイメージをpullするよう設定する。

## 関連Issue

Fixes: #61

## 修正内容

- `docker-compose.yml` の `plant-diary` サービスに `pull_policy: always` を追加

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Docker イメージ取得の設定を更新しました。コンテナ起動時にイメージが常に最新の状態で取得されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->