### PR TITLE
#74 スライドショーの日付を日記詳細へのリンクにする

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -249,6 +249,7 @@ func (s *Server) handleSlideshow(w http.ResponseWriter, r *http.Request) {
 	type photoItem struct {
 		URL      string `json:"url"`
 		DateTime string `json:"dateTime"`
+		DiaryID  int    `json:"diaryId"`
 	}
 	photos := make([]photoItem, 0, len(diaries))
 	for i := range diaries {
@@ -262,6 +263,7 @@ func (s *Server) handleSlideshow(w http.ResponseWriter, r *http.Request) {
 		photos = append(photos, photoItem{
 			URL:      "/photos/" + diaries[i].ImagePath,
 			DateTime: dateTime,
+			DiaryID:  diaries[i].ID,
 		})
 	}
 	photosJSON, err := json.Marshal(photos)

--- a/app/templates/slideshow.html
+++ b/app/templates/slideshow.html
@@ -118,6 +118,15 @@
             margin-bottom: 16px;
         }
 
+        .slideshow-info a {
+            color: #555555;
+            text-decoration: underline;
+        }
+
+        .slideshow-info a:hover {
+            color: #4a7c59;
+        }
+
         .slideshow-controls {
             display: flex;
             flex-wrap: wrap;
@@ -258,7 +267,12 @@
                 currentIndex = (index + photos.length) % photos.length;
                 var photo = photos[currentIndex];
                 document.getElementById('slideshow-img').src = photo.url;
-                document.getElementById('slideshow-datetime').textContent = photo.dateTime;
+                var datetimeEl = document.getElementById('slideshow-datetime');
+                var link = document.createElement('a');
+                link.href = '/diary/' + photo.diaryId;
+                link.textContent = photo.dateTime;
+                datetimeEl.innerHTML = '';
+                datetimeEl.appendChild(link);
                 document.getElementById('slideshow-progress').textContent = (currentIndex + 1) + ' / ' + photos.length;
             }
 


### PR DESCRIPTION
## 概要

スライドショー画面で各スライドに表示されている日付部分を、対応する日記詳細ページへのリンクにする。これにより、スライドショーを閲覧中に直接その日記の詳細を確認できるようになる。

## 関連Issue

Fixes: #74

## 修正内容

- `app/server.go`: `handleSlideshow` 関数の `photoItem` 構造体に `DiaryID` フィールドを追加し、JSONデータに `diaryId` を含めるようにした
- `app/templates/slideshow.html`:
  - `showSlide` 関数で日付テキストを `<a href="/diary/{diaryId}">` リンクとして生成するよう変更
  - リンクのスタイル（通常時・ホバー時）を追加

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スライドショーの日時表示がダイアリーページへのリンクに変わりました。各写真をクリックして対応するダイアリーエントリに移動できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->