### PR TITLE
#76 明るさ自動調整付き撮影スクリプトを追加

### DIFF
--- a/scripts/capture_auto.sh
+++ b/scripts/capture_auto.sh
@@ -42,9 +42,16 @@ EXPOSURE_FILE="${PROJECT_DIR}/data/last_exposure.txt"
 TARGET_BRIGHTNESS="${1:-0.475}"
 MAX_ADJUST_RETRIES="${2:-5}"
 
-# 適正輝度範囲の算出
-BRIGHTNESS_MIN=$(echo "${TARGET_BRIGHTNESS} - ${BRIGHTNESS_TOLERANCE}" | bc -l)
-BRIGHTNESS_MAX=$(echo "${TARGET_BRIGHTNESS} + ${BRIGHTNESS_TOLERANCE}" | bc -l)
+# 引数バリデーション
+if ! [[ "${TARGET_BRIGHTNESS}" =~ ^(0(\.[0-9]+)?|1(\.0+)?)$ ]]; then
+    echo "ERROR: TARGET_BRIGHTNESS は 0〜1 の数値で指定してください。" >&2
+    exit 1
+fi
+
+if ! [[ "${MAX_ADJUST_RETRIES}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: MAX_ADJUST_RETRIES は 1 以上の整数で指定してください。" >&2
+    exit 1
+fi
 
 # 一時ファイル管理
 TMP_FILES=()
@@ -139,6 +146,10 @@ if ! command -v bc &> /dev/null; then
     echo "ERROR: bc が見つかりません。" >&2
     exit 1
 fi
+
+# 適正輝度範囲の算出
+BRIGHTNESS_MIN=$(echo "${TARGET_BRIGHTNESS} - ${BRIGHTNESS_TOLERANCE}" | bc -l)
+BRIGHTNESS_MAX=$(echo "${TARGET_BRIGHTNESS} + ${BRIGHTNESS_TOLERANCE}" | bc -l)
 
 # ファイル名の生成（YYYYMMDD_HHMM_UTC.jpg）
 DATE=$(date -u +%Y%m%d_%H%M_UTC)


### PR DESCRIPTION
## Summary
- 明るさ自動調整付き撮影スクリプト `scripts/capture_auto.sh` を新規作成
- 既存の `capture.sh` は変更なし
- ImageMagick で撮影画像の平均輝度を算出し、露出を自動調整して適正な明るさで撮影する

## 変更内容
### 新規ファイル: `scripts/capture_auto.sh`
- **明るさ判定**: `convert` コマンドでグレースケール変換後、平均輝度（0.0〜1.0）を取得
- **適正範囲**: 0.30〜0.65（範囲外なら露出を調整して再撮影）
- **露出調整**: 暗すぎ→2倍、明るすぎ→半分（上限5000、下限10）
- **前回値の再利用**: `data/last_exposure.txt` に露出値を保存・読み込み
- **最大リトライ**: 5回。上限到達時は適正範囲の中央値（0.475）に最も近い画像を採用
- **一時ファイルクリーンアップ**: `trap` で EXIT/INT/TERM をキャッチし `_tmp_` ファイルを確実に削除
- **ログ出力**: 各試行の露出値と平均輝度を `data/capture.log` に記録

## Test plan
- [ ] ImageMagick 未インストール環境でエラー終了することを確認
- [ ] fswebcam 未インストール環境でエラー終了することを確認
- [ ] USBカメラ接続環境で撮影・自動調整が動作することを確認
- [ ] `data/last_exposure.txt` の保存・読み込みが正しく動作することを確認
- [ ] スクリプト中断時に一時ファイルが削除されることを確認

Closes #76

https://claude.ai/code/session_01ArF9d9VuffkPEUGbBKd8Kw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * USBカメラからの自動写真キャプチャ機能を追加しました
  * 自動明るさ調整で最適な露出を探索し、必要に応じて複数回再試行します
  * 目標輝度に合わせた最終画像をUTCタイムスタンプ付きで保存します
  * 最終露出値を保存して次回撮影に活用します
  * 撮影の進捗や結果をログに記録します
  * 再試行が上限に達した場合は最も目標輝度に近い試行画像を採用します
<!-- end of auto-generated comment: release notes by coderabbit.ai -->