### PR TITLE
外部プラグインの改善提案先URLを明記

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,7 +18,7 @@
 - `base-tools:solve-issue`: Issue解決フロー
 - `base-tools:setup-worktree`: worktree作成
 
-これらのスキルは外部プラグイン（canpok1-plugins/base-tools）で管理されており、このリポジトリでは編集できません。改善提案がある場合は、該当プラグインのリポジトリにIssueを作成してください。
+これらのスキルは外部プラグイン（canpok1-plugins/base-tools）で管理されており、このリポジトリでは編集できません。改善提案がある場合は、https://github.com/canpok1/claude-code-plugins にIssueを作成してください。
 
 ## agent teamの使用指針
 


### PR DESCRIPTION
## 概要

CLAUDE.md の外部プラグインに関する改善提案先を、具体的なURLに更新しました。

## 変更内容

- 外部プラグイン（canpok1-plugins/base-tools）への改善提案先として `https://github.com/canpok1/claude-code-plugins` を明記

## 背景

以前は「該当プラグインのリポジトリにIssueを作成してください」という曖昧な記載だったため、登録先が明確でなかった。実際に plant-diary の Issue として外部プラグイン向けの改善案が蓄積していたため、URLを明示することで正しい登録先に誘導する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション
  * 外部プラグイン貢献の案内をGitHubリポジトリへの直接URLに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->