### PR TITLE
#83 DBマイグレーション: diaryテーブルへのuser_id追加と既存データ移行

### DIFF
--- a/app/migrations/000004_add_user_id_to_diary.down.sql
+++ b/app/migrations/000004_add_user_id_to_diary.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE diary DROP COLUMN user_id;

--- a/app/migrations/000004_add_user_id_to_diary.up.sql
+++ b/app/migrations/000004_add_user_id_to_diary.up.sql
@@ -1,0 +1,10 @@
+-- systemユーザーを作成（ログイン不可、既存データ移行用）
+INSERT OR IGNORE INTO users (uuid, username, password_hash, created_at)
+VALUES ('00000000000000000000000000000000', 'system', 'DISABLED', CURRENT_TIMESTAMP);
+
+-- user_idカラム追加（NULL許容）
+ALTER TABLE diary ADD COLUMN user_id INTEGER REFERENCES users(id);
+
+-- 既存データをsystemユーザーに割り当て
+UPDATE diary SET user_id = (SELECT id FROM users WHERE username = 'system')
+WHERE user_id IS NULL;


### PR DESCRIPTION
## 概要

diaryテーブルにuser_idカラムを追加し、既存データをsystemユーザーに割り当てるマイグレーションを実装しました。

Closes #83

## 変更内容

### 追加ファイル

- `app/migrations/000004_add_user_id_to_diary.up.sql`
  - systemユーザー（ログイン不可、既存データ移行用）を `INSERT OR IGNORE` で作成
  - diaryテーブルに `user_id INTEGER REFERENCES users(id)` カラムを追加（NULL許容）
  - 既存データのuser_idをsystemユーザーのIDに更新

- `app/migrations/000004_add_user_id_to_diary.down.sql`
  - `user_id` カラムを削除（ロールバック用）

## 備考

- systemユーザーのUUIDは固定値（`000...0`の32文字）
- `INSERT OR IGNORE` により冪等性を確保
- 既存の写真ファイルは移動しない（後方互換性を維持）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダイアリー機能をユーザーアカウント連携に対応させました。ユーザーごとの独立したダイアリー管理が実現され、マルチユーザー環境での利用が可能になります。既存のダイアリーレコードは自動的に移行されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->