### PR TITLE
#102 watch-issue.shからsolve-issue.shを呼び出すように変更し、solve-issue.shに-pオプションを追加

### DIFF
--- a/.claude/scripts/solve-issue.sh
+++ b/.claude/scripts/solve-issue.sh
@@ -6,9 +6,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# オプション解析
+USE_PRINT_MODE=false
+while getopts "p" opt; do
+  case "$opt" in
+    p) USE_PRINT_MODE=true ;;
+    *) echo "Usage: $0 [-p] <issue_number>" >&2; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
 # 引数チェック
 if [ $# -ne 1 ]; then
-  echo "Usage: $0 <issue_number>" >&2
+  echo "Usage: $0 [-p] <issue_number>" >&2
   exit 1
 fi
 
@@ -30,4 +40,8 @@ git checkout -b "${BRANCH_NAME}"
 echo "ブランチ ${BRANCH_NAME} を作成しました"
 
 # Claudeでissueを解決
-claude --dangerously-skip-permissions "/solve-issue ${ISSUE_NUMBER}"
+if "${USE_PRINT_MODE}"; then
+  claude --dangerously-skip-permissions -p "/solve-issue ${ISSUE_NUMBER}"
+else
+  claude --dangerously-skip-permissions "/solve-issue ${ISSUE_NUMBER}"
+fi

--- a/.claude/scripts/watch-issue.sh
+++ b/.claude/scripts/watch-issue.sh
@@ -23,8 +23,8 @@ for issue_number in $issues; do
   # エラー時にラベルを削除するトラップを設定
   trap "gh issue edit \"$issue_number\" --remove-label \"in-progress-by-claude\" || true" ERR
 
-  # claudeコマンドを実行
-  claude --add-dir /workspaces -p "/solve-issue $issue_number"
+  # solve-issue.shを実行
+  "$(dirname "$0")/solve-issue.sh" -p "$issue_number"
 
   # トラップを解除
   trap - ERR


### PR DESCRIPTION
## 概要

`watch-issue.sh` が直接 `claude` コマンドを呼び出していた部分を、`solve-issue.sh` を呼び出すように変更した。
また、`solve-issue.sh` に `-p` オプションを追加して、`claude -p`（非インタラクティブモード）での実行を制御できるようにした。

## 関連Issue

Fixes: #102

## 修正内容

- `.claude/scripts/solve-issue.sh`
  - `-p` オプションを追加（`getopts` で実装）
  - `-p` 指定時: `claude --dangerously-skip-permissions -p "/solve-issue $ISSUE_NUMBER"` で実行
  - `-p` 未指定時: `claude --dangerously-skip-permissions "/solve-issue $ISSUE_NUMBER"` で実行（従来の動作を維持）
  - Usage表示を `[-p]` オプションを含む形式に更新

- `.claude/scripts/watch-issue.sh`
  - `claude` コマンドの直接呼び出しを削除
  - 代わりに `solve-issue.sh -p "$issue_number"` を呼び出すように変更

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)