### PR TITLE
#110 solve-issue.sh: 作業ブランチ作成を --worktree オプションに置き換える

### DIFF
--- a/.claude/scripts/solve-issue.sh
+++ b/.claude/scripts/solve-issue.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cleanup() {
-  git checkout main >/dev/null 2>&1 || true
-}
-trap cleanup EXIT
-
 # オプション解析
 USE_PRINT_MODE=false
 while getopts "p" opt; do
@@ -27,7 +22,6 @@ if ! [[ "${ISSUE_NUMBER}" =~ ^[0-9]+$ ]]; then
   echo "Error: issue_number must be numeric" >&2
   exit 1
 fi
-BRANCH_NAME="feature/issue${ISSUE_NUMBER}"
 
 echo "Issue #${ISSUE_NUMBER} の処理を開始します"
 
@@ -35,13 +29,9 @@ echo "Issue #${ISSUE_NUMBER} の処理を開始します"
 git checkout main
 git pull origin main
 
-# 作業ブランチを作成・切り替え
-git checkout -b "${BRANCH_NAME}"
-echo "ブランチ ${BRANCH_NAME} を作成しました"
-
-# Claudeでissueを解決
+# Claudeでissueを解決（--worktreeで自動的にブランチとワークツリーを作成）
 if "${USE_PRINT_MODE}"; then
-  claude --dangerously-skip-permissions -p "/solve-issue ${ISSUE_NUMBER}"
+  claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions -p "/solve-issue ${ISSUE_NUMBER}"
 else
-  claude --dangerously-skip-permissions "/solve-issue ${ISSUE_NUMBER}"
+  claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions "/solve-issue ${ISSUE_NUMBER}"
 fi


### PR DESCRIPTION
## 概要

`solve-issue.sh` の手動ブランチ作成コードを削除し、Claude の `--worktree` オプションに一本化します。

## 変更内容

- `cleanup()` 関数と `trap cleanup EXIT` を削除（worktree は Claude が自動管理するため不要）
- `BRANCH_NAME` 変数と `git checkout -b` による手動ブランチ作成を削除
- `claude` コマンドに `--worktree "issue-${ISSUE_NUMBER}"` オプションを追加
  - ワークツリー名・ブランチ名: `issue-{番号}`（例: `issue-1`）
  - print mode あり・なしの両方に対応

## 動作

| 項目 | 変更前 | 変更後 |
|---|---|---|
| ブランチ作成 | `git checkout -b feature/issue{番号}` | `--worktree "issue-{番号}"` で自動作成 |
| ブランチ名 | `feature/issue{番号}` | `issue-{番号}` |
| main 最新化 | `git pull origin main` | `git pull origin main`（維持） |
| teardown | 手動 | Claude の `--worktree` が自動対応 |

Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 問題解決ワークフローを簡素化しました。Claude のワークツリーモード機能を活用することで、ブランチ管理がより効率化されました。手動でのブランチ切り替えが不要になり、開発プロセスがスムーズになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->