### PR TITLE
#112 booksテーブル・ドメインモデルの実装

### DIFF
--- a/app/db.go
+++ b/app/db.go
@@ -165,6 +165,15 @@ func (r *SQLiteDiaryRepository) CreateDiaryForUser(userID int, imagePath, conten
 	return err
 }
 
+// CreateDiaryForBook は指定日記帳・クリエイターの新しい日記エントリを作成する
+func (r *SQLiteDiaryRepository) CreateDiaryForBook(bookID, creatorID int, imagePath, content string, createdAt time.Time) error {
+	_, err := r.db.Exec(
+		"INSERT INTO diary (image_path, content, created_at, user_id, book_id) VALUES (?, ?, ?, ?, ?)",
+		imagePath, content, createdAt, creatorID, bookID,
+	)
+	return err
+}
+
 // UpdateDiaryContent は指定IDの日記のcontentを更新し、updated_atも現在時刻に更新する
 func (r *SQLiteDiaryRepository) UpdateDiaryContent(id int, content string) error {
 	result, err := r.db.Exec(
@@ -415,6 +424,117 @@ func (r *SQLiteSessionRepository) GetSessionByID(id string) (*Session, error) {
 func (r *SQLiteSessionRepository) DeleteSession(id string) error {
 	_, err := r.db.Exec("DELETE FROM sessions WHERE id = ?", id)
 	return err
+}
+
+// SQLiteBookRepository はSQLiteを使用したBookRepositoryの実装
+type SQLiteBookRepository struct {
+	db *sql.DB
+}
+
+// NewSQLiteBookRepository は新しいSQLiteBookRepositoryを生成する
+func NewSQLiteBookRepository(db *sql.DB) *SQLiteBookRepository {
+	return &SQLiteBookRepository{db: db}
+}
+
+// CreateBook は新しい日記帳を作成する
+func (r *SQLiteBookRepository) CreateBook(creatorID int, name string) (*Book, error) {
+	uuid, err := generateUUID()
+	if err != nil {
+		return nil, err
+	}
+	uploadKey, err := generateUUID()
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := r.db.Exec(
+		"INSERT INTO books (uuid, creator_id, name, upload_key) VALUES (?, ?, ?, ?)",
+		uuid, creatorID, name, uploadKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+
+	return r.GetBookByID(int(id))
+}
+
+// GetBooksByCreatorID は指定クリエイターIDの日記帳一覧を返す
+func (r *SQLiteBookRepository) GetBooksByCreatorID(creatorID int) ([]Book, error) {
+	rows, err := r.db.Query(
+		"SELECT id, uuid, creator_id, name, upload_key, created_at FROM books WHERE creator_id = ?",
+		creatorID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var books []Book
+	for rows.Next() {
+		var b Book
+		if err := rows.Scan(&b.ID, &b.UUID, &b.CreatorID, &b.Name, &b.UploadKey, &b.CreatedAt); err != nil {
+			return nil, err
+		}
+		books = append(books, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return books, nil
+}
+
+// GetBookByID は指定IDの日記帳を返す。見つからない場合はnilを返す
+func (r *SQLiteBookRepository) GetBookByID(id int) (*Book, error) {
+	var b Book
+	err := r.db.QueryRow(
+		"SELECT id, uuid, creator_id, name, upload_key, created_at FROM books WHERE id = ?",
+		id,
+	).Scan(&b.ID, &b.UUID, &b.CreatorID, &b.Name, &b.UploadKey, &b.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// GetBookByUploadKey は指定upload_keyの日記帳を返す。見つからない場合はnilを返す
+func (r *SQLiteBookRepository) GetBookByUploadKey(uploadKey string) (*Book, error) {
+	var b Book
+	err := r.db.QueryRow(
+		"SELECT id, uuid, creator_id, name, upload_key, created_at FROM books WHERE upload_key = ?",
+		uploadKey,
+	).Scan(&b.ID, &b.UUID, &b.CreatorID, &b.Name, &b.UploadKey, &b.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// DeleteBook は指定IDの日記帳を削除する
+func (r *SQLiteBookRepository) DeleteBook(id int) error {
+	result, err := r.db.Exec("DELETE FROM books WHERE id = ?", id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("book %d not found", id)
+	}
+	return nil
 }
 
 // GetDiariesInDateRange は指定日付範囲内の日記を古い順（created_at ASC）で返す

--- a/app/db_test.go
+++ b/app/db_test.go
@@ -16,14 +16,6 @@ func setupTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("failed to open database: %v", err)
 	}
 	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS diary (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			image_path TEXT NOT NULL UNIQUE,
-			content TEXT NOT NULL,
-			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			user_id INTEGER REFERENCES users(id)
-		);
-		CREATE INDEX IF NOT EXISTS idx_created_at ON diary(created_at DESC);
 		CREATE TABLE IF NOT EXISTS users (
 			id            INTEGER PRIMARY KEY AUTOINCREMENT,
 			uuid          TEXT NOT NULL UNIQUE,
@@ -31,6 +23,23 @@ func setupTestDB(t *testing.T) *sql.DB {
 			password_hash TEXT NOT NULL,
 			created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);
+		CREATE TABLE IF NOT EXISTS books (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			uuid       TEXT NOT NULL UNIQUE,
+			creator_id INTEGER NOT NULL REFERENCES users(id),
+			name       TEXT NOT NULL,
+			upload_key TEXT NOT NULL UNIQUE,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS diary (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			image_path TEXT NOT NULL UNIQUE,
+			content TEXT NOT NULL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			user_id INTEGER REFERENCES users(id),
+			book_id INTEGER REFERENCES books(id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_created_at ON diary(created_at DESC);
 		CREATE TABLE IF NOT EXISTS sessions (
 			id         TEXT PRIMARY KEY,
 			user_id    INTEGER NOT NULL REFERENCES users(id),
@@ -686,4 +695,248 @@ func TestSQLiteSessionRepository_ImplementsInterface(t *testing.T) {
 	db := setupTestDB(t)
 	// コンパイル時にインターフェースを満たすことを確認
 	var _ SessionRepository = NewSQLiteSessionRepository(db)
+}
+
+func TestSQLiteBookRepository_CreateBook(t *testing.T) {
+	db := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	bookRepo := NewSQLiteBookRepository(db)
+
+	if err := userRepo.CreateUser("uuid-001", "alice", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	alice, err := userRepo.GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+
+	book, err := bookRepo.CreateBook(alice.ID, "Alice's Garden")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected book, got nil")
+	}
+	if book.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+	if len(book.UUID) != 32 {
+		t.Errorf("expected UUID length 32, got %d", len(book.UUID))
+	}
+	if book.CreatorID != alice.ID {
+		t.Errorf("expected CreatorID %d, got %d", alice.ID, book.CreatorID)
+	}
+	if book.Name != "Alice's Garden" {
+		t.Errorf("expected Name 'Alice's Garden', got '%s'", book.Name)
+	}
+	if len(book.UploadKey) != 32 {
+		t.Errorf("expected UploadKey length 32, got %d", len(book.UploadKey))
+	}
+	if book.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+}
+
+func TestSQLiteBookRepository_GetBooksByCreatorID(t *testing.T) {
+	db := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	bookRepo := NewSQLiteBookRepository(db)
+
+	if err := userRepo.CreateUser("uuid-001", "alice", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	if err := userRepo.CreateUser("uuid-002", "bob", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	alice, err := userRepo.GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+	bob, err := userRepo.GetUserByUsername("bob")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+
+	if _, err := bookRepo.CreateBook(alice.ID, "Alice Book 1"); err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+	if _, err := bookRepo.CreateBook(alice.ID, "Alice Book 2"); err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+	if _, err := bookRepo.CreateBook(bob.ID, "Bob Book 1"); err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	aliceBooks, err := bookRepo.GetBooksByCreatorID(alice.ID)
+	if err != nil {
+		t.Fatalf("GetBooksByCreatorID failed: %v", err)
+	}
+	if len(aliceBooks) != 2 {
+		t.Errorf("expected 2 books for alice, got %d", len(aliceBooks))
+	}
+
+	bobBooks, err := bookRepo.GetBooksByCreatorID(bob.ID)
+	if err != nil {
+		t.Fatalf("GetBooksByCreatorID failed: %v", err)
+	}
+	if len(bobBooks) != 1 {
+		t.Errorf("expected 1 book for bob, got %d", len(bobBooks))
+	}
+}
+
+func TestSQLiteBookRepository_GetBookByID(t *testing.T) {
+	db := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	bookRepo := NewSQLiteBookRepository(db)
+
+	if err := userRepo.CreateUser("uuid-001", "alice", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	alice, err := userRepo.GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+
+	created, err := bookRepo.CreateBook(alice.ID, "Test Book")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	book, err := bookRepo.GetBookByID(created.ID)
+	if err != nil {
+		t.Fatalf("GetBookByID failed: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected book, got nil")
+	}
+	if book.Name != "Test Book" {
+		t.Errorf("expected Name 'Test Book', got '%s'", book.Name)
+	}
+
+	// 存在しないIDを取得
+	notFound, err := bookRepo.GetBookByID(9999)
+	if err != nil {
+		t.Fatalf("GetBookByID failed: %v", err)
+	}
+	if notFound != nil {
+		t.Errorf("expected nil for non-existent ID, got %v", notFound)
+	}
+}
+
+func TestSQLiteBookRepository_GetBookByUploadKey(t *testing.T) {
+	db := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	bookRepo := NewSQLiteBookRepository(db)
+
+	if err := userRepo.CreateUser("uuid-001", "alice", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	alice, err := userRepo.GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+
+	created, err := bookRepo.CreateBook(alice.ID, "Test Book")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	book, err := bookRepo.GetBookByUploadKey(created.UploadKey)
+	if err != nil {
+		t.Fatalf("GetBookByUploadKey failed: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected book, got nil")
+	}
+	if book.ID != created.ID {
+		t.Errorf("expected ID %d, got %d", created.ID, book.ID)
+	}
+
+	// 存在しないキーを取得
+	notFound, err := bookRepo.GetBookByUploadKey("nonexistent")
+	if err != nil {
+		t.Fatalf("GetBookByUploadKey failed: %v", err)
+	}
+	if notFound != nil {
+		t.Errorf("expected nil for non-existent key, got %v", notFound)
+	}
+}
+
+func TestSQLiteBookRepository_DeleteBook(t *testing.T) {
+	db := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	bookRepo := NewSQLiteBookRepository(db)
+
+	if err := userRepo.CreateUser("uuid-001", "alice", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	alice, err := userRepo.GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+
+	created, err := bookRepo.CreateBook(alice.ID, "Test Book")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	if err := bookRepo.DeleteBook(created.ID); err != nil {
+		t.Fatalf("DeleteBook failed: %v", err)
+	}
+
+	// 削除後に取得するとnilを返す
+	book, err := bookRepo.GetBookByID(created.ID)
+	if err != nil {
+		t.Fatalf("GetBookByID failed: %v", err)
+	}
+	if book != nil {
+		t.Errorf("expected nil after deletion, got %v", book)
+	}
+
+	// 存在しないIDを削除するとエラー
+	if err := bookRepo.DeleteBook(9999); err == nil {
+		t.Error("expected error for non-existent ID, got nil")
+	}
+}
+
+func TestSQLiteBookRepository_ImplementsInterface(t *testing.T) {
+	db := setupTestDB(t)
+	// コンパイル時にインターフェースを満たすことを確認
+	var _ BookRepository = NewSQLiteBookRepository(db)
+}
+
+func TestSQLiteDiaryRepository_CreateDiaryForBook(t *testing.T) {
+	db := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	bookRepo := NewSQLiteBookRepository(db)
+	diaryRepo := NewSQLiteDiaryRepository(db)
+
+	if err := userRepo.CreateUser("uuid-001", "alice", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	alice, err := userRepo.GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+
+	book, err := bookRepo.CreateBook(alice.ID, "Test Book")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	err = diaryRepo.CreateDiaryForBook(book.ID, alice.ID, "/path/to/image.jpg", "テスト日記", time.Now())
+	if err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+
+	diaries, err := diaryRepo.GetAllDiaries()
+	if err != nil {
+		t.Fatalf("GetAllDiaries failed: %v", err)
+	}
+	if len(diaries) != 1 {
+		t.Fatalf("expected 1 diary, got %d", len(diaries))
+	}
+	if diaries[0].ImagePath != "/path/to/image.jpg" {
+		t.Errorf("expected ImagePath '/path/to/image.jpg', got '%s'", diaries[0].ImagePath)
+	}
 }

--- a/app/main.go
+++ b/app/main.go
@@ -43,6 +43,9 @@ func main() {
 	// UserRepository の初期化（SQLite実装）
 	userRepo := NewSQLiteUserRepository(db)
 
+	// BookRepository の初期化（SQLite実装）
+	_ = NewSQLiteBookRepository(db)
+
 	// SessionRepository の初期化（SQLite実装）
 	sessionRepo := NewSQLiteSessionRepository(db)
 

--- a/app/migrations/000005_add_books.down.sql
+++ b/app/migrations/000005_add_books.down.sql
@@ -1,0 +1,5 @@
+-- book_idカラムを削除
+ALTER TABLE diary DROP COLUMN book_id;
+
+-- booksテーブルを削除
+DROP TABLE IF EXISTS books;

--- a/app/migrations/000005_add_books.up.sql
+++ b/app/migrations/000005_add_books.up.sql
@@ -1,0 +1,31 @@
+-- booksテーブルを作成
+CREATE TABLE IF NOT EXISTS books (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    uuid       TEXT NOT NULL UNIQUE,
+    creator_id INTEGER NOT NULL REFERENCES users(id),
+    name       TEXT NOT NULL,
+    upload_key TEXT NOT NULL UNIQUE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- diaryテーブルにbook_idカラムを追加
+ALTER TABLE diary ADD COLUMN book_id INTEGER REFERENCES books(id);
+
+-- systemユーザーのデフォルト日記帳を作成
+INSERT INTO books (uuid, creator_id, name, upload_key, created_at)
+SELECT
+    '00000000000000000000000000000001',
+    id,
+    'デフォルト',
+    '00000000000000000000000000000002',
+    CURRENT_TIMESTAMP
+FROM users WHERE username = 'system';
+
+-- 既存のdiaryをデフォルト日記帳に紐付け
+UPDATE diary SET book_id = (
+    SELECT books.id FROM books
+    JOIN users ON books.creator_id = users.id
+    WHERE users.username = 'system'
+    LIMIT 1
+)
+WHERE book_id IS NULL;

--- a/app/repository.go
+++ b/app/repository.go
@@ -22,6 +22,16 @@ type Diary struct {
 	CreatedAt time.Time
 }
 
+// Book は日記帳を表す構造体
+type Book struct {
+	ID        int
+	UUID      string
+	CreatorID int
+	Name      string
+	UploadKey string
+	CreatedAt time.Time
+}
+
 // User はユーザーを表す構造体
 type User struct {
 	ID           int
@@ -29,6 +39,15 @@ type User struct {
 	Username     string
 	PasswordHash string
 	CreatedAt    time.Time
+}
+
+// BookRepository は日記帳データへのアクセスを定義するインターフェース
+type BookRepository interface {
+	CreateBook(creatorID int, name string) (*Book, error)
+	GetBooksByCreatorID(creatorID int) ([]Book, error)
+	GetBookByID(id int) (*Book, error)
+	GetBookByUploadKey(uploadKey string) (*Book, error)
+	DeleteBook(id int) error
 }
 
 // UserRepository はユーザーデータへのアクセスを定義するインターフェース
@@ -60,6 +79,7 @@ type DiaryRepository interface {
 	GetDiaryByID(id int) (*Diary, error)
 	CreateDiary(imagePath, content string, createdAt time.Time) error
 	CreateDiaryForUser(userID int, imagePath, content string, createdAt time.Time) error
+	CreateDiaryForBook(bookID, creatorID int, imagePath, content string, createdAt time.Time) error
 	UpdateDiaryContent(id int, content string) error
 	IsImageProcessed(imagePath string) (bool, error)
 	GetLatestDiaryCreatedAt() (time.Time, error)
@@ -135,6 +155,11 @@ func (r *MockDiaryRepository) UpdateDiaryContent(id int, content string) error {
 
 // CreateDiaryForUser は指定ユーザーの新しい日記エントリを作成する（モックではuserIDを無視）
 func (r *MockDiaryRepository) CreateDiaryForUser(userID int, imagePath, content string, createdAt time.Time) error {
+	return r.CreateDiary(imagePath, content, createdAt)
+}
+
+// CreateDiaryForBook は指定日記帳・クリエイターの新しい日記エントリを作成する（モックではbookID/creatorIDを無視）
+func (r *MockDiaryRepository) CreateDiaryForBook(bookID, creatorID int, imagePath, content string, createdAt time.Time) error {
 	return r.CreateDiary(imagePath, content, createdAt)
 }
 
@@ -278,4 +303,101 @@ func (r *MockDiaryRepository) GetDiariesInDateRange(startDate, endDate time.Time
 	}
 
 	return result, nil
+}
+
+// MockBookRepository はメモリ上でデータを保持するモック実装
+type MockBookRepository struct {
+	mu     sync.RWMutex
+	books  map[int]*Book
+	nextID int
+}
+
+// NewMockBookRepository は新しいMockBookRepositoryを生成する
+func NewMockBookRepository() *MockBookRepository {
+	return &MockBookRepository{
+		books:  make(map[int]*Book),
+		nextID: 1,
+	}
+}
+
+// CreateBook は新しい日記帳を作成する
+func (r *MockBookRepository) CreateBook(creatorID int, name string) (*Book, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	uuid, err := generateUUID()
+	if err != nil {
+		return nil, err
+	}
+	uploadKey, err := generateUUID()
+	if err != nil {
+		return nil, err
+	}
+
+	book := &Book{
+		ID:        r.nextID,
+		UUID:      uuid,
+		CreatorID: creatorID,
+		Name:      name,
+		UploadKey: uploadKey,
+		CreatedAt: time.Now(),
+	}
+	r.books[r.nextID] = book
+	r.nextID++
+
+	copy := *book
+	return &copy, nil
+}
+
+// GetBooksByCreatorID は指定クリエイターIDの日記帳一覧を返す
+func (r *MockBookRepository) GetBooksByCreatorID(creatorID int) ([]Book, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]Book, 0)
+	for _, b := range r.books {
+		if b.CreatorID == creatorID {
+			result = append(result, *b)
+		}
+	}
+	return result, nil
+}
+
+// GetBookByID は指定IDの日記帳を返す。見つからない場合はnilを返す
+func (r *MockBookRepository) GetBookByID(id int) (*Book, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	b, ok := r.books[id]
+	if !ok {
+		return nil, nil
+	}
+	copy := *b
+	return &copy, nil
+}
+
+// GetBookByUploadKey は指定upload_keyの日記帳を返す。見つからない場合はnilを返す
+func (r *MockBookRepository) GetBookByUploadKey(uploadKey string) (*Book, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, b := range r.books {
+		if b.UploadKey == uploadKey {
+			copy := *b
+			return &copy, nil
+		}
+	}
+	return nil, nil
+}
+
+// DeleteBook は指定IDの日記帳を削除する
+func (r *MockBookRepository) DeleteBook(id int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.books[id]; !ok {
+		return fmt.Errorf("book %d not found", id)
+	}
+	delete(r.books, id)
+	return nil
 }

--- a/app/repository_test.go
+++ b/app/repository_test.go
@@ -5,6 +5,153 @@ import (
 	"time"
 )
 
+func TestMockBookRepository_CreateBook(t *testing.T) {
+	repo := NewMockBookRepository()
+
+	book, err := repo.CreateBook(1, "Test Book")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected book, got nil")
+	}
+	if book.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+	if book.CreatorID != 1 {
+		t.Errorf("expected CreatorID 1, got %d", book.CreatorID)
+	}
+	if book.Name != "Test Book" {
+		t.Errorf("expected Name 'Test Book', got '%s'", book.Name)
+	}
+	if book.UUID == "" {
+		t.Error("expected non-empty UUID")
+	}
+	if book.UploadKey == "" {
+		t.Error("expected non-empty UploadKey")
+	}
+}
+
+func TestMockBookRepository_GetBooksByCreatorID(t *testing.T) {
+	repo := NewMockBookRepository()
+
+	if _, err := repo.CreateBook(1, "Alice Book 1"); err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+	if _, err := repo.CreateBook(1, "Alice Book 2"); err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+	if _, err := repo.CreateBook(2, "Bob Book 1"); err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	aliceBooks, err := repo.GetBooksByCreatorID(1)
+	if err != nil {
+		t.Fatalf("GetBooksByCreatorID failed: %v", err)
+	}
+	if len(aliceBooks) != 2 {
+		t.Errorf("expected 2 books for creator 1, got %d", len(aliceBooks))
+	}
+
+	bobBooks, err := repo.GetBooksByCreatorID(2)
+	if err != nil {
+		t.Fatalf("GetBooksByCreatorID failed: %v", err)
+	}
+	if len(bobBooks) != 1 {
+		t.Errorf("expected 1 book for creator 2, got %d", len(bobBooks))
+	}
+}
+
+func TestMockBookRepository_GetBookByID(t *testing.T) {
+	repo := NewMockBookRepository()
+
+	created, err := repo.CreateBook(1, "Test Book")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	book, err := repo.GetBookByID(created.ID)
+	if err != nil {
+		t.Fatalf("GetBookByID failed: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected book, got nil")
+	}
+	if book.Name != "Test Book" {
+		t.Errorf("expected Name 'Test Book', got '%s'", book.Name)
+	}
+
+	// 存在しないIDを取得
+	notFound, err := repo.GetBookByID(9999)
+	if err != nil {
+		t.Fatalf("GetBookByID failed: %v", err)
+	}
+	if notFound != nil {
+		t.Errorf("expected nil for non-existent ID, got %v", notFound)
+	}
+}
+
+func TestMockBookRepository_GetBookByUploadKey(t *testing.T) {
+	repo := NewMockBookRepository()
+
+	created, err := repo.CreateBook(1, "Test Book")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	book, err := repo.GetBookByUploadKey(created.UploadKey)
+	if err != nil {
+		t.Fatalf("GetBookByUploadKey failed: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected book, got nil")
+	}
+	if book.ID != created.ID {
+		t.Errorf("expected ID %d, got %d", created.ID, book.ID)
+	}
+
+	// 存在しないキーを取得
+	notFound, err := repo.GetBookByUploadKey("nonexistent")
+	if err != nil {
+		t.Fatalf("GetBookByUploadKey failed: %v", err)
+	}
+	if notFound != nil {
+		t.Errorf("expected nil for non-existent key, got %v", notFound)
+	}
+}
+
+func TestMockBookRepository_DeleteBook(t *testing.T) {
+	repo := NewMockBookRepository()
+
+	created, err := repo.CreateBook(1, "Test Book")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	if err := repo.DeleteBook(created.ID); err != nil {
+		t.Fatalf("DeleteBook failed: %v", err)
+	}
+
+	// 削除後に取得するとnilを返す
+	book, err := repo.GetBookByID(created.ID)
+	if err != nil {
+		t.Fatalf("GetBookByID failed: %v", err)
+	}
+	if book != nil {
+		t.Errorf("expected nil after deletion, got %v", book)
+	}
+
+	// 存在しないIDを削除するとエラー
+	if err := repo.DeleteBook(9999); err == nil {
+		t.Error("expected error for non-existent ID, got nil")
+	}
+}
+
+func TestMockBookRepository_ImplementsInterface(t *testing.T) {
+	// コンパイル時にインターフェースを満たすことを確認
+	var _ BookRepository = NewMockBookRepository()
+}
+
 func TestMockDiaryRepository_CreateDiary(t *testing.T) {
 	repo := NewMockDiaryRepository()
 


### PR DESCRIPTION
## 概要

日記帳（Book）の概念を追加するための DB・ドメイン基盤を実装する。
booksテーブルとそのドメインモデル・リポジトリを追加し、既存のdiaryデータとの関連付けも行う。

## 関連Issue

Fixes: #112

## 修正内容

### DBマイグレーション (`app/migrations/000005_add_books.*`)
- `books` テーブルを追加（`id`, `uuid`, `creator_id`, `name`, `upload_key`, `created_at`）
- `diary` テーブルに `book_id` カラムを追加
- 既存データ移行: system ユーザーにデフォルト日記帳を作成し、既存 diary を紐付け

### ドメインモデル (`app/repository.go`)
- `Book` struct を追加
- `BookRepository` インターフェースを追加（`CreateBook`, `GetBooksByCreatorID`, `GetBookByID`, `GetBookByUploadKey`, `DeleteBook`）
- `MockBookRepository` を追加
- `DiaryRepository` に `CreateDiaryForBook(bookID, creatorID int, imagePath, content string, createdAt time.Time) error` を追加

### SQLite実装 (`app/db.go`)
- `SQLiteBookRepository` を実装（既存 `generateUUID()` 関数を流用）
- `SQLiteDiaryRepository.CreateDiaryForBook` を実装

### テスト・初期化
- `app/db_test.go`: `setupTestDB` 更新（booksテーブル追加・diaryにbook_id追加）、`TestSQLiteBookRepository_*` 追加
- `app/repository_test.go`: `TestMockBookRepository_*` 追加
- `app/main.go`: `NewSQLiteBookRepository(db)` 追加

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)