### PR TITLE
#113 OpenAPI仕様の変更とコード再生成（UPLOAD_API_KEY廃止）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,3 @@
 # Google AI Studio で取得: https://aistudio.google.com/apikey
 GEMINI_API_KEY=your_api_key_here
 
-# 写真登録API キー（capture_auto.sh で --api-url / --user-uuid を指定する場合に必須）
-# プロセスリスト露出を防ぐため環境変数で管理する
-UPLOAD_API_KEY=your_upload_api_key_here

--- a/app/api.gen.go
+++ b/app/api.gen.go
@@ -6,16 +6,11 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
-)
-
-const (
-	ApiKeyAuthScopes = "ApiKeyAuth.Scopes"
 )
 
 // CreateUserRequest defines model for CreateUserRequest.
@@ -28,7 +23,7 @@ type CreateUserRequest struct {
 type UploadPhotoRequest struct {
 	CapturedAt *time.Time         `json:"captured_at,omitempty"`
 	Photo      openapi_types.File `json:"photo"`
-	UserUuid   string             `json:"user_uuid"`
+	UploadKey  string             `json:"upload_key"`
 }
 
 // UploadPhotoResponse defines model for UploadPhotoResponse.
@@ -70,12 +65,6 @@ type MiddlewareFunc func(http.Handler) http.Handler
 // PostApiPhotos operation middleware
 func (siw *ServerInterfaceWrapper) PostApiPhotos(w http.ResponseWriter, r *http.Request) {
 
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, ApiKeyAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PostApiPhotos(w, r)
 	}))
@@ -89,12 +78,6 @@ func (siw *ServerInterfaceWrapper) PostApiPhotos(w http.ResponseWriter, r *http.
 
 // PostApiUsers operation middleware
 func (siw *ServerInterfaceWrapper) PostApiUsers(w http.ResponseWriter, r *http.Request) {
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, ApiKeyAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PostApiUsers(w, r)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -11,8 +11,6 @@ paths:
     post:
       summary: ユーザーを作成する
       operationId: postApiUsers
-      security:
-        - ApiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -38,8 +36,6 @@ paths:
     post:
       summary: 写真をアップロードする
       operationId: postApiPhotos
-      security:
-        - ApiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -62,11 +58,6 @@ paths:
         '500':
           description: Internal Server Error
 components:
-  securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-API-Key
   schemas:
     CreateUserRequest:
       type: object
@@ -92,13 +83,15 @@ components:
       type: object
       required:
         - photo
-        - user_uuid
+        - upload_key
       properties:
         photo:
           type: string
           format: binary
-        user_uuid:
+        upload_key:
           type: string
+          minLength: 32
+          maxLength: 32
         captured_at:
           type: string
           format: date-time


### PR DESCRIPTION
## 概要

Issue #113 の対応として、UPLOAD_API_KEY廃止とupload_key認証への移行に向けてOpenAPI仕様を更新しコードを再生成した。

## 変更内容

### `docs/openapi.yaml`
- `components.securitySchemes.ApiKeyAuth` を削除
- `/api/users` と `/api/photos` の `security` セクションを削除
- `UploadPhotoRequest` の `user_uuid` フィールドを `upload_key`（32文字必須）に変更

### `app/api.gen.go`
- oapi-codegen で再生成
  - `ApiKeyAuthScopes` 定数を削除
  - `UploadPhotoRequest.UserUuid` → `UploadPhotoRequest.UploadKey` に変更
  - APIキー認証のコンテキスト設定コードを削除

### `.env.example`
- `UPLOAD_API_KEY` 行を削除

## 確認事項

- [x] `go build ./...` が通ること

Closes #113