### PR TITLE
#121 watch-issue.shのチケット処理順を古いものから新しいものに変更

### DIFF
--- a/.claude/scripts/watch-issue.sh
+++ b/.claude/scripts/watch-issue.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# assign-to-claudeラベル付き、かつin-progress-by-claudeラベルが付いていないissueを取得
+# assign-to-claudeラベル付き、かつin-progress-by-claudeラベルが付いていないissueを取得（古い順）
 issues=$(gh issue list \
   --label "assign-to-claude" \
+  --sort created \
+  --order asc \
   --json number,labels \
   --jq '.[] | select(.labels | map(.name) | contains(["in-progress-by-claude"]) | not) | .number')
 


### PR DESCRIPTION
## 変更内容

`watch-issue.sh` の `gh issue list` コマンドに `--sort created --order asc` オプションを追加し、Issueを古い順（作成日昇順）で処理するようにしました。

## 変更の背景

これまでデフォルトのソート順（新→古）でIssueが処理されていたため、新しいIssueが優先されてしまっていました。先に作成されたIssueを優先して処理するために、処理順を古いものから新しいものに変更しました。

## 変更ファイル

- `.claude/scripts/watch-issue.sh`: `gh issue list` に `--sort created --order asc` を追加

Closes #121