### PR TITLE
enabledPluginsにbase-tools@canpok1-pluginsを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -101,7 +101,9 @@
     "type": "command",
     "command": "./.claude/statusline.sh"
   },
-  "enabledPlugins": {},
+  "enabledPlugins": {
+    "base-tools@canpok1-plugins": true
+  },
   "extraKnownMarketplaces": {
     "canpok1-plugins": {
       "source": {


### PR DESCRIPTION
## 概要
Claude Code の設定ファイル（`.claude/settings.json`）の `enabledPlugins` に `base-tools@canpok1-plugins` プラグインを有効化する設定を追加。
これにより、`create-pr`、`fix-pr`、`teardown-worktree`、`retro`、`setup-worktree` などの base-tools スキルが利用可能になる。

## 修正内容
- `.claude/settings.json` の `enabledPlugins` に `"base-tools@canpok1-plugins": true` を追加

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)