### PR TITLE
#134 日記帳別スライドショー機能の追加

### DIFF
--- a/app/db.go
+++ b/app/db.go
@@ -597,6 +597,41 @@ func (r *SQLiteDiaryRepository) GetDiariesByBookID(bookID int) ([]Diary, error) 
 	return diaries, nil
 }
 
+// GetDiariesByBookIDAsc は指定日記帳IDの日記を古い順（created_at ASC）で返す。from/toがゼロ値の場合はその条件を無視する
+func (r *SQLiteDiaryRepository) GetDiariesByBookIDAsc(bookID int, from, to time.Time) ([]Diary, error) {
+	var rows *sql.Rows
+	var err error
+
+	switch {
+	case from.IsZero() && to.IsZero():
+		rows, err = r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE book_id = ? ORDER BY created_at ASC", bookID)
+	case from.IsZero():
+		rows, err = r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE book_id = ? AND created_at <= ? ORDER BY created_at ASC", bookID, to)
+	case to.IsZero():
+		rows, err = r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE book_id = ? AND created_at >= ? ORDER BY created_at ASC", bookID, from)
+	default:
+		rows, err = r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE book_id = ? AND created_at >= ? AND created_at <= ? ORDER BY created_at ASC", bookID, from, to)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var diaries []Diary
+	for rows.Next() {
+		var d Diary
+		if err := rows.Scan(&d.ID, &d.ImagePath, &d.Content, &d.CreatedAt); err != nil {
+			return nil, err
+		}
+		diaries = append(diaries, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return diaries, nil
+}
+
 // GetDiariesInDateRange は指定日付範囲内の日記を古い順（created_at ASC）で返す
 func (r *SQLiteDiaryRepository) GetDiariesInDateRange(startDate, endDate time.Time) ([]Diary, error) {
 	rows, err := r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE created_at >= ? AND created_at <= ? ORDER BY created_at ASC", startDate, endDate)

--- a/app/db_test.go
+++ b/app/db_test.go
@@ -983,6 +983,126 @@ func TestSQLiteBookRepository_ImplementsInterface(t *testing.T) {
 	var _ BookRepository = NewSQLiteBookRepository(db)
 }
 
+func TestSQLiteDiaryRepository_GetDiariesByBookIDAsc(t *testing.T) {
+	db := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	bookRepo := NewSQLiteBookRepository(db)
+	diaryRepo := NewSQLiteDiaryRepository(db)
+
+	if err := userRepo.CreateUser("uuid-001", "alice", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	alice, err := userRepo.GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+
+	book1, err := bookRepo.CreateBook(alice.ID, "Book 1")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+	book2, err := bookRepo.CreateBook(alice.ID, "Book 2")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	// 存在しないbookIDを指定した場合はnilを返す
+	diaries, err := diaryRepo.GetDiariesByBookIDAsc(9999, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc failed: %v", err)
+	}
+	if diaries != nil {
+		t.Errorf("expected nil for non-existent bookID, got %v", diaries)
+	}
+
+	// 日記を追加
+	time1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	time2 := time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC)
+	time3 := time.Date(2026, 1, 3, 10, 0, 0, 0, time.UTC)
+	time4 := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
+
+	if err := diaryRepo.CreateDiaryForBook(book1.ID, alice.ID, "/path/1.jpg", "日記1", time1); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := diaryRepo.CreateDiaryForBook(book1.ID, alice.ID, "/path/2.jpg", "日記2", time2); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := diaryRepo.CreateDiaryForBook(book1.ID, alice.ID, "/path/3.jpg", "日記3", time3); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := diaryRepo.CreateDiaryForBook(book1.ID, alice.ID, "/path/4.jpg", "日記4", time4); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := diaryRepo.CreateDiaryForBook(book2.ID, alice.ID, "/path/5.jpg", "日記5", time1); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+
+	// 全件取得（book1の4件）
+	diaries, err = diaryRepo.GetDiariesByBookIDAsc(book1.ID, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc failed: %v", err)
+	}
+	if len(diaries) != 4 {
+		t.Fatalf("expected 4 diaries for book1, got %d", len(diaries))
+	}
+
+	// 古い順（created_at ASC）であることを確認
+	if diaries[0].Content != "日記1" {
+		t.Errorf("expected first diary to be '日記1', got '%s'", diaries[0].Content)
+	}
+	if diaries[3].Content != "日記4" {
+		t.Errorf("expected last diary to be '日記4', got '%s'", diaries[3].Content)
+	}
+
+	// fromフィルタ
+	diaries, err = diaryRepo.GetDiariesByBookIDAsc(book1.ID, time2, time.Time{})
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc with from failed: %v", err)
+	}
+	if len(diaries) != 3 {
+		t.Fatalf("expected 3 diaries with from filter, got %d", len(diaries))
+	}
+	if diaries[0].Content != "日記2" {
+		t.Errorf("expected first diary to be '日記2', got '%s'", diaries[0].Content)
+	}
+
+	// toフィルタ
+	diaries, err = diaryRepo.GetDiariesByBookIDAsc(book1.ID, time.Time{}, time2)
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc with to failed: %v", err)
+	}
+	if len(diaries) != 2 {
+		t.Fatalf("expected 2 diaries with to filter, got %d", len(diaries))
+	}
+	if diaries[1].Content != "日記2" {
+		t.Errorf("expected second diary to be '日記2', got '%s'", diaries[1].Content)
+	}
+
+	// from+toフィルタ
+	diaries, err = diaryRepo.GetDiariesByBookIDAsc(book1.ID, time2, time3)
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc with from+to failed: %v", err)
+	}
+	if len(diaries) != 2 {
+		t.Fatalf("expected 2 diaries with from+to filter, got %d", len(diaries))
+	}
+	if diaries[0].Content != "日記2" {
+		t.Errorf("expected first diary to be '日記2', got '%s'", diaries[0].Content)
+	}
+	if diaries[1].Content != "日記3" {
+		t.Errorf("expected second diary to be '日記3', got '%s'", diaries[1].Content)
+	}
+
+	// 別の日記帳（book2）は取得されない
+	diaries, err = diaryRepo.GetDiariesByBookIDAsc(book2.ID, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc for book2 failed: %v", err)
+	}
+	if len(diaries) != 1 {
+		t.Fatalf("expected 1 diary for book2, got %d", len(diaries))
+	}
+}
+
 func TestSQLiteDiaryRepository_CreateDiaryForBook(t *testing.T) {
 	db := setupTestDB(t)
 	userRepo := NewSQLiteUserRepository(db)

--- a/app/repository.go
+++ b/app/repository.go
@@ -97,6 +97,7 @@ type DiaryRepository interface {
 	GetAvailableYearMonths() ([]YearMonth, error)
 	SearchDiaries(keyword string) ([]Diary, error)
 	GetDiariesAsc(from, to time.Time) ([]Diary, error)
+	GetDiariesByBookIDAsc(bookID int, from, to time.Time) ([]Diary, error)
 }
 
 // MockDiaryRepository はメモリ上でデータを保持するモック実装
@@ -317,6 +318,34 @@ func (r *MockDiaryRepository) GetDiariesAsc(from, to time.Time) ([]Diary, error)
 		if from.IsZero() || (d.CreatedAt.Equal(from) || d.CreatedAt.After(from)) {
 			if to.IsZero() || (d.CreatedAt.Equal(to) || d.CreatedAt.Before(to)) {
 				result = append(result, *d)
+			}
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].CreatedAt.Before(result[j].CreatedAt)
+	})
+
+	return result, nil
+}
+
+// GetDiariesByBookIDAsc は指定日記帳IDの日記を古い順で返す。from/toがゼロ値の場合はその条件を無視する
+func (r *MockDiaryRepository) GetDiariesByBookIDAsc(bookID int, from, to time.Time) ([]Diary, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	diaryIDs, ok := r.bookDiaries[bookID]
+	if !ok {
+		return nil, nil
+	}
+
+	result := make([]Diary, 0)
+	for _, id := range diaryIDs {
+		if d, ok := r.diaries[id]; ok {
+			if from.IsZero() || (d.CreatedAt.Equal(from) || d.CreatedAt.After(from)) {
+				if to.IsZero() || (d.CreatedAt.Equal(to) || d.CreatedAt.Before(to)) {
+					result = append(result, *d)
+				}
 			}
 		}
 	}

--- a/app/repository_test.go
+++ b/app/repository_test.go
@@ -500,6 +500,106 @@ func TestMockDiaryRepository_GetDiariesInDateRange_Empty(t *testing.T) {
 	}
 }
 
+func TestMockDiaryRepository_GetDiariesByBookIDAsc(t *testing.T) {
+	repo := NewMockDiaryRepository()
+
+	// 存在しないbookIDを指定した場合はnilを返す
+	diaries, err := repo.GetDiariesByBookIDAsc(1, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc failed: %v", err)
+	}
+	if diaries != nil {
+		t.Errorf("expected nil for non-existent bookID, got %v", diaries)
+	}
+
+	// 複数の日記帳に日記を作成
+	time1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	time2 := time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC)
+	time3 := time.Date(2026, 1, 3, 10, 0, 0, 0, time.UTC)
+	time4 := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
+
+	if err := repo.CreateDiaryForBook(1, 100, "/path/1.jpg", "日記1", time1); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(1, 100, "/path/2.jpg", "日記2", time2); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(1, 100, "/path/3.jpg", "日記3", time3); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(1, 100, "/path/4.jpg", "日記4", time4); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(2, 100, "/path/5.jpg", "日記5", time1); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+
+	// 全件取得（bookID=1の4件）
+	diaries, err = repo.GetDiariesByBookIDAsc(1, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc failed: %v", err)
+	}
+	if len(diaries) != 4 {
+		t.Fatalf("expected 4 diaries for bookID 1, got %d", len(diaries))
+	}
+
+	// 古い順（created_at ASC）であることを確認
+	if diaries[0].Content != "日記1" {
+		t.Errorf("expected first diary to be '日記1', got '%s'", diaries[0].Content)
+	}
+	if diaries[3].Content != "日記4" {
+		t.Errorf("expected last diary to be '日記4', got '%s'", diaries[3].Content)
+	}
+
+	// fromフィルタ
+	diaries, err = repo.GetDiariesByBookIDAsc(1, time2, time.Time{})
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc with from failed: %v", err)
+	}
+	if len(diaries) != 3 {
+		t.Fatalf("expected 3 diaries with from filter, got %d", len(diaries))
+	}
+	if diaries[0].Content != "日記2" {
+		t.Errorf("expected first diary to be '日記2', got '%s'", diaries[0].Content)
+	}
+
+	// toフィルタ
+	diaries, err = repo.GetDiariesByBookIDAsc(1, time.Time{}, time2)
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc with to failed: %v", err)
+	}
+	if len(diaries) != 2 {
+		t.Fatalf("expected 2 diaries with to filter, got %d", len(diaries))
+	}
+	if diaries[1].Content != "日記2" {
+		t.Errorf("expected second diary to be '日記2', got '%s'", diaries[1].Content)
+	}
+
+	// from+toフィルタ
+	diaries, err = repo.GetDiariesByBookIDAsc(1, time2, time3)
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc with from+to failed: %v", err)
+	}
+	if len(diaries) != 2 {
+		t.Fatalf("expected 2 diaries with from+to filter, got %d", len(diaries))
+	}
+	if diaries[0].Content != "日記2" {
+		t.Errorf("expected first diary to be '日記2', got '%s'", diaries[0].Content)
+	}
+	if diaries[1].Content != "日記3" {
+		t.Errorf("expected second diary to be '日記3', got '%s'", diaries[1].Content)
+	}
+
+	// 別の日記帳（bookID=2）は独立して取得できる
+	diaries, err = repo.GetDiariesByBookIDAsc(2, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("GetDiariesByBookIDAsc for bookID 2 failed: %v", err)
+	}
+	if len(diaries) != 1 {
+		t.Fatalf("expected 1 diary for bookID 2, got %d", len(diaries))
+	}
+}
+
 func TestMockDiaryRepository_GetDiariesByBookID(t *testing.T) {
 	repo := NewMockDiaryRepository()
 

--- a/app/server.go
+++ b/app/server.go
@@ -84,6 +84,7 @@ func NewServer(repo DiaryRepository, userRepo UserRepository, bookRepo BookRepos
 	s.mux.HandleFunc("GET /books", s.requireLogin(s.handleGetBooks))
 	s.mux.HandleFunc("POST /books", s.requireLogin(s.handlePostBooks))
 	s.mux.HandleFunc("GET /books/{id}", s.handleGetBook)
+	s.mux.HandleFunc("GET /books/{id}/slideshow", s.handleBookSlideshow)
 
 	HandlerFromMux(s, s.mux)
 
@@ -479,16 +480,109 @@ func (s *Server) handleSlideshow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := map[string]interface{}{
-		"Diaries":    diaries,
-		"From":       fromStr,
-		"To":         toStr,
-		"PhotosJSON": template.JS(photosJSON),
+		"Diaries":       diaries,
+		"From":          fromStr,
+		"To":            toStr,
+		"PhotosJSON":    template.JS(photosJSON),
+		"FilterBaseURL": "/slideshow",
 	}
 
 	if err := s.templates.ExecuteTemplate(w, "slideshow.html", data); err != nil {
 		log.Printf("ERROR: failed to render slideshow template: %v", err)
 		s.renderError(w, http.StatusInternalServerError)
 		return
+	}
+}
+
+// handleBookSlideshow は日記帳別スライドショーページを表示する
+func (s *Server) handleBookSlideshow(w http.ResponseWriter, r *http.Request) {
+	idStr := r.PathValue("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		log.Printf("ERROR: invalid book id: %s", idStr)
+		s.renderError(w, http.StatusNotFound)
+		return
+	}
+
+	book, err := s.bookRepo.GetBookByID(id)
+	if err != nil {
+		log.Printf("ERROR: failed to get book %d: %v", id, err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+	if book == nil {
+		s.renderError(w, http.StatusNotFound)
+		return
+	}
+
+	fromStr := r.URL.Query().Get("from")
+	toStr := r.URL.Query().Get("to")
+
+	var from, to time.Time
+	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
+
+	if fromStr != "" {
+		t, err := time.ParseInLocation("2006-01-02", fromStr, jst)
+		if err == nil {
+			from = t.UTC()
+		}
+	}
+	if toStr != "" {
+		t, err := time.ParseInLocation("2006-01-02", toStr, jst)
+		if err == nil {
+			to = t.Add(24*time.Hour - time.Nanosecond).UTC()
+		}
+	}
+
+	diaries, err := s.repo.GetDiariesByBookIDAsc(id, from, to)
+	if err != nil {
+		log.Printf("ERROR: failed to get diaries for book slideshow %d: %v", id, err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+
+	jstZone := time.FixedZone("Asia/Tokyo", 9*60*60)
+	weekdays := []string{"日", "月", "火", "水", "木", "金", "土"}
+	type photoItem struct {
+		URL      string `json:"url"`
+		DateTime string `json:"dateTime"`
+		DiaryID  int    `json:"diaryId"`
+	}
+	photos := make([]photoItem, 0, len(diaries))
+	for i := range diaries {
+		diaries[i].ImagePath = filepath.Base(diaries[i].ImagePath)
+		t := diaries[i].CreatedAt.In(jstZone)
+		dateTime := fmt.Sprintf("%d年%d月%d日（%s）%s",
+			t.Year(), int(t.Month()), t.Day(),
+			weekdays[t.Weekday()],
+			t.Format("15:04"),
+		)
+		photos = append(photos, photoItem{
+			URL:      "/photos/" + diaries[i].ImagePath,
+			DateTime: dateTime,
+			DiaryID:  diaries[i].ID,
+		})
+	}
+	photosJSON, err := json.Marshal(photos)
+	if err != nil {
+		log.Printf("ERROR: failed to marshal photos JSON: %v", err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+
+	data := map[string]interface{}{
+		"Diaries":       diaries,
+		"From":          fromStr,
+		"To":            toStr,
+		"PhotosJSON":    template.JS(photosJSON),
+		"BookName":      book.Name,
+		"BackURL":       fmt.Sprintf("/books/%d", id),
+		"FilterBaseURL": fmt.Sprintf("/books/%d/slideshow", id),
+	}
+
+	if err := s.templates.ExecuteTemplate(w, "slideshow.html", data); err != nil {
+		log.Printf("ERROR: failed to render slideshow template for book %d: %v", id, err)
+		s.renderError(w, http.StatusInternalServerError)
 	}
 }
 

--- a/app/templates/book_detail.html
+++ b/app/templates/book_detail.html
@@ -193,6 +193,21 @@
             text-decoration: underline;
         }
 
+        .slideshow-link {
+            display: inline-block;
+            margin-bottom: 24px;
+            padding: 8px 16px;
+            font-size: 0.95rem;
+            color: #ffffff;
+            background-color: #4a7c59;
+            border-radius: 6px;
+            text-decoration: none;
+        }
+
+        .slideshow-link:hover {
+            background-color: #3a6347;
+        }
+
         .empty-message {
             text-align: center;
             color: #888888;
@@ -250,6 +265,10 @@
     <main>
         <p class="book-title">{{.Book.Name}}</p>
         <p class="book-meta">作成日時: {{(.Book.CreatedAt | toJST).Format "2006年1月2日 15:04"}}</p>
+
+        {{if .Diaries}}
+        <a class="slideshow-link" href="/books/{{.Book.ID}}/slideshow">スライドショーで見る</a>
+        {{end}}
 
         {{if .IsOwner}}
         <p class="section-label">アップロードキー</p>

--- a/app/templates/slideshow.html
+++ b/app/templates/slideshow.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>スライドショー - 植物観察日記</title>
+    <title>{{if .BookName}}{{.BookName}} - スライドショー{{else}}スライドショー{{end}} - 植物観察日記</title>
     <style>
         * {
             margin: 0;
@@ -218,8 +218,8 @@
 </head>
 <body>
     <header>
-        <h1>スライドショー</h1>
-        <nav><a href="/">← 日記一覧</a></nav>
+        <h1>{{if .BookName}}{{.BookName}} - スライドショー{{else}}スライドショー{{end}}</h1>
+        <nav>{{if .BackURL}}<a href="{{.BackURL}}">← 日記帳に戻る</a>{{else}}<a href="/">← 日記一覧</a>{{end}}</nav>
     </header>
     <main>
         <form class="filter-form" onsubmit="applyFilter(event)">
@@ -324,7 +324,8 @@
                 var params = [];
                 if (from) params.push('from=' + encodeURIComponent(from));
                 if (to) params.push('to=' + encodeURIComponent(to));
-                window.location.href = params.length > 0 ? '/slideshow?' + params.join('&') : '/slideshow';
+                var baseURL = "{{.FilterBaseURL}}";
+                window.location.href = params.length > 0 ? baseURL + '?' + params.join('&') : baseURL;
             }
 
             showSlide(0);


### PR DESCRIPTION
## 概要

日記帳単位でスライドショーを閲覧できる機能を追加します。

Closes #134

## 変更内容

### バックエンド

- `DiaryRepository` インターフェースに `GetDiariesByBookIDAsc` メソッドを追加
- `MockDiaryRepository` に `GetDiariesByBookIDAsc` の実装を追加
- `SQLiteDiaryRepository` に `GetDiariesByBookIDAsc` の実装を追加
  - `book_id` でフィルタし、`from`/`to` の日付フィルタに対応
- `server.go` に `handleBookSlideshow` ハンドラーと `GET /books/{id}/slideshow` ルーティングを追加
- 既存の `handleSlideshow` に `FilterBaseURL` を渡すよう変更

### フロントエンド

- `book_detail.html`: 日記帳名の下に「スライドショーで見る」リンクを追加（日記が0件の場合は非表示）
- `slideshow.html`: `BookName`・`BackURL`・`FilterBaseURL` テンプレート変数に対応
  - 日記帳別スライドショーでは `{日記帳名} - スライドショー` をタイトルに表示
  - 「← 日記帳に戻る」の戻るリンクを追加
  - 日付フィルタのリダイレクト先を動的に切り替え

### テスト

- `db_test.go`: `TestSQLiteDiaryRepository_GetDiariesByBookIDAsc` を追加
- `repository_test.go`: `TestMockDiaryRepository_GetDiariesByBookIDAsc` を追加

## 動作確認

- `go test ./...` が全て通ることを確認済み