### PR TITLE
#136 capture_auto.sh の引数・フォームフィールドを API 仕様に合わせて修正

### DIFF
--- a/scripts/capture_auto.sh
+++ b/scripts/capture_auto.sh
@@ -10,18 +10,15 @@ set -euo pipefail
 # 基本: ./scripts/capture_auto.sh
 # 目標輝度を指定: ./scripts/capture_auto.sh 0.5
 # 目標輝度と最大試行回数を指定: ./scripts/capture_auto.sh 0.5 8
-# API登録付き: ./scripts/capture_auto.sh 0.5 8 --api-url http://192.168.1.10:8080 --user-uuid 550e8400e29b41d4a716446655440000
+# API登録付き: ./scripts/capture_auto.sh 0.5 8 --api-url http://192.168.1.10:8080 --upload-key your32charkey
 #
 #   引数1: TARGET_BRIGHTNESS（省略時: 0.475）
 #          0〜1の浮動小数点値で目標とする平均輝度を指定する。
 #          許容誤差（BRIGHTNESS_TOLERANCE）はスクリプト内の定数で調整できる。
 #   引数2: MAX_ADJUST_RETRIES（省略時: 5）
 #          明るさ調整の最大試行回数を指定する。
-#   --api-url: APIのベースURL。--user-uuid とセットで指定する（省略可）。
-#   --user-uuid: ユーザーUUID（ハイフンなし32文字）。--api-url とセットで指定する（省略可）。
-#
-# === 環境変数 ===
-# UPLOAD_API_KEY: APIキー。--api-url / --user-uuid 指定時は必須。
+#   --api-url: APIのベースURL。--upload-key とセットで指定する（省略可）。
+#   --upload-key: 日記帳のアップロードキー（32文字）。--api-url とセットで指定する（省略可）。
 #
 # === 前提条件 ===
 # - fswebcam がインストールされていること
@@ -47,7 +44,7 @@ EXPOSURE_FILE="${PROJECT_DIR}/data/last_exposure.txt"
 
 # 引数のパース
 DIARY_API_URL=""
-DIARY_USER_UUID=""
+DIARY_UPLOAD_KEY=""
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -57,12 +54,12 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       DIARY_API_URL="$2"; shift 2 ;;
-    --user-uuid)
+    --upload-key)
       if [[ -z "${2:-}" || "$2" == --* ]]; then
-        echo "ERROR: --user-uuid には値が必要です。" >&2
+        echo "ERROR: --upload-key には値が必要です。" >&2
         exit 1
       fi
-      DIARY_USER_UUID="$2"; shift 2 ;;
+      DIARY_UPLOAD_KEY="$2"; shift 2 ;;
     *) POSITIONAL+=("$1"); shift ;;
   esac
 done
@@ -83,16 +80,12 @@ if ! [[ "${MAX_ADJUST_RETRIES}" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 # フラグのバリデーション（片方だけの指定はエラー）
-if [ -n "${DIARY_API_URL}" ] && [ -z "${DIARY_USER_UUID}" ]; then
-    echo "ERROR: --api-url を指定する場合は --user-uuid も必要です。" >&2
+if [ -n "${DIARY_API_URL}" ] && [ -z "${DIARY_UPLOAD_KEY}" ]; then
+    echo "ERROR: --api-url を指定する場合は --upload-key も必要です。" >&2
     exit 1
 fi
-if [ -z "${DIARY_API_URL}" ] && [ -n "${DIARY_USER_UUID}" ]; then
-    echo "ERROR: --user-uuid を指定する場合は --api-url も必要です。" >&2
-    exit 1
-fi
-if [ -n "${DIARY_API_URL}" ] && [ -z "${UPLOAD_API_KEY:-}" ]; then
-    echo "ERROR: API登録を行う場合は環境変数 UPLOAD_API_KEY が必要です。" >&2
+if [ -z "${DIARY_API_URL}" ] && [ -n "${DIARY_UPLOAD_KEY}" ]; then
+    echo "ERROR: --upload-key を指定する場合は --api-url も必要です。" >&2
     exit 1
 fi
 
@@ -254,12 +247,11 @@ for ((i = 1; i <= MAX_ADJUST_RETRIES; i++)); do
         log_message "INFO: Captured ${FINAL_OUTPUT}"
         echo "撮影成功: ${FINAL_OUTPUT}"
 
-        # API登録（--api-url と --user-uuid が両方指定された場合のみ）
+        # API登録（--api-url と --upload-key が両方指定された場合のみ）
         if [ -n "${DIARY_API_URL}" ]; then
             curl -s -X POST \
-              -H "X-API-Key: ${UPLOAD_API_KEY}" \
               -F "photo=@${FINAL_OUTPUT}" \
-              -F "user_uuid=${DIARY_USER_UUID}" \
+              -F "upload_key=${DIARY_UPLOAD_KEY}" \
               "${DIARY_API_URL}/api/photos" || log_message "WARN: API upload failed (photo saved locally)"
         fi
 
@@ -318,11 +310,10 @@ log_message "INFO: 露出値を保存: ${BEST_EXPOSURE}"
 log_message "INFO: Captured ${FINAL_OUTPUT}"
 echo "撮影成功: ${FINAL_OUTPUT}"
 
-# API登録（--api-url と --user-uuid が両方指定された場合のみ）
+# API登録（--api-url と --upload-key が両方指定された場合のみ）
 if [ -n "${DIARY_API_URL}" ]; then
     curl -s -X POST \
-      -H "X-API-Key: ${UPLOAD_API_KEY}" \
       -F "photo=@${FINAL_OUTPUT}" \
-      -F "user_uuid=${DIARY_USER_UUID}" \
+      -F "upload_key=${DIARY_UPLOAD_KEY}" \
       "${DIARY_API_URL}/api/photos" || log_message "WARN: API upload failed (photo saved locally)"
 fi


### PR DESCRIPTION
## 概要

`capture_auto.sh` が `POST /api/photos` に送信するリクエストがサーバーの API 仕様と一致していなかったため、一致するように修正しました。

## 関連Issue

Fixes: #136

## 修正内容

- `--user-uuid` オプションを `--upload-key` に変更
- `UPLOAD_API_KEY` 環境変数を廃止（不要なため削除）
- curl のフォームフィールドを `user_uuid` → `upload_key` に変更
- `X-API-Key` ヘッダーを削除
- コメント・ドキュメントを更新（使い方の例、引数説明、環境変数セクションの削除）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)