### PR TITLE
#138 /slideshow ページを廃止する

### DIFF
--- a/app/db.go
+++ b/app/db.go
@@ -271,41 +271,6 @@ func (r *SQLiteDiaryRepository) SearchDiaries(keyword string) ([]Diary, error) {
 	return diaries, nil
 }
 
-// GetDiariesAsc は全日記または指定期間の日記を古い順（created_at ASC）で返す。from/toがゼロ値の場合はその条件を無視する
-func (r *SQLiteDiaryRepository) GetDiariesAsc(from, to time.Time) ([]Diary, error) {
-	var rows *sql.Rows
-	var err error
-
-	switch {
-	case from.IsZero() && to.IsZero():
-		rows, err = r.db.Query("SELECT id, image_path, content, created_at FROM diary ORDER BY created_at ASC")
-	case from.IsZero():
-		rows, err = r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE created_at <= ? ORDER BY created_at ASC", to)
-	case to.IsZero():
-		rows, err = r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE created_at >= ? ORDER BY created_at ASC", from)
-	default:
-		rows, err = r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE created_at >= ? AND created_at <= ? ORDER BY created_at ASC", from, to)
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var diaries []Diary
-	for rows.Next() {
-		var d Diary
-		if err := rows.Scan(&d.ID, &d.ImagePath, &d.Content, &d.CreatedAt); err != nil {
-			return nil, err
-		}
-		diaries = append(diaries, d)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return diaries, nil
-}
-
 // generateUUID はhyphenなし32文字のUUIDを生成する
 func generateUUID() (string, error) {
 	b := make([]byte, 16)

--- a/app/repository.go
+++ b/app/repository.go
@@ -96,7 +96,6 @@ type DiaryRepository interface {
 	GetDiariesInDateRange(startDate, endDate time.Time) ([]Diary, error)
 	GetAvailableYearMonths() ([]YearMonth, error)
 	SearchDiaries(keyword string) ([]Diary, error)
-	GetDiariesAsc(from, to time.Time) ([]Diary, error)
 	GetDiariesByBookIDAsc(bookID int, from, to time.Time) ([]Diary, error)
 }
 
@@ -303,27 +302,6 @@ func (r *MockDiaryRepository) SearchDiaries(keyword string) ([]Diary, error) {
 
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].CreatedAt.After(result[j].CreatedAt)
-	})
-
-	return result, nil
-}
-
-// GetDiariesAsc は全日記または指定期間の日記を古い順で返す。from/toがゼロ値の場合は全件取得
-func (r *MockDiaryRepository) GetDiariesAsc(from, to time.Time) ([]Diary, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	result := make([]Diary, 0)
-	for _, d := range r.diaries {
-		if from.IsZero() || (d.CreatedAt.Equal(from) || d.CreatedAt.After(from)) {
-			if to.IsZero() || (d.CreatedAt.Equal(to) || d.CreatedAt.Before(to)) {
-				result = append(result, *d)
-			}
-		}
-	}
-
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].CreatedAt.Before(result[j].CreatedAt)
 	})
 
 	return result, nil

--- a/app/server.go
+++ b/app/server.go
@@ -77,7 +77,6 @@ func NewServer(repo DiaryRepository, userRepo UserRepository, bookRepo BookRepos
 	s.mux.HandleFunc("POST /diary/{id}/edit", s.requireLogin(s.handleDiaryEditPost))
 	s.mux.HandleFunc("GET /photos/{filename}", s.handlePhoto)
 	s.mux.HandleFunc("GET /photos/{user_uuid}/{filename}", s.handlePhotoWithUserUUID)
-	s.mux.HandleFunc("GET /slideshow", s.handleSlideshow)
 	s.mux.HandleFunc("GET /login", s.handleLoginGet)
 	s.mux.HandleFunc("POST /login", s.handleLoginPost)
 	s.mux.HandleFunc("POST /logout", s.handleLogout)
@@ -418,80 +417,6 @@ func (s *Server) handlePhotoWithUserUUID(w http.ResponseWriter, r *http.Request)
 
 	filePath := filepath.Join(s.photosDir, userUUID, filename)
 	http.ServeFile(w, r, filePath)
-}
-
-// handleSlideshow はスライドショーページを表示する
-func (s *Server) handleSlideshow(w http.ResponseWriter, r *http.Request) {
-	fromStr := r.URL.Query().Get("from")
-	toStr := r.URL.Query().Get("to")
-
-	var from, to time.Time
-	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
-
-	if fromStr != "" {
-		t, err := time.ParseInLocation("2006-01-02", fromStr, jst)
-		if err == nil {
-			from = t.UTC()
-		}
-	}
-	if toStr != "" {
-		t, err := time.ParseInLocation("2006-01-02", toStr, jst)
-		if err == nil {
-			// 終了日は当日の終わりまで含める
-			to = t.Add(24*time.Hour - time.Nanosecond).UTC()
-		}
-	}
-
-	diaries, err := s.repo.GetDiariesAsc(from, to)
-	if err != nil {
-		log.Printf("ERROR: failed to get diaries for slideshow: %v", err)
-		s.renderError(w, http.StatusInternalServerError)
-		return
-	}
-
-	// ImagePathをファイル名のみに変換し、JavaScript用データを準備
-	jstZone := time.FixedZone("Asia/Tokyo", 9*60*60)
-	weekdays := []string{"日", "月", "火", "水", "木", "金", "土"}
-	type photoItem struct {
-		URL      string `json:"url"`
-		DateTime string `json:"dateTime"`
-		DiaryID  int    `json:"diaryId"`
-	}
-	photos := make([]photoItem, 0, len(diaries))
-	for i := range diaries {
-		diaries[i].ImagePath = filepath.Base(diaries[i].ImagePath)
-		t := diaries[i].CreatedAt.In(jstZone)
-		dateTime := fmt.Sprintf("%d年%d月%d日（%s）%s",
-			t.Year(), int(t.Month()), t.Day(),
-			weekdays[t.Weekday()],
-			t.Format("15:04"),
-		)
-		photos = append(photos, photoItem{
-			URL:      "/photos/" + diaries[i].ImagePath,
-			DateTime: dateTime,
-			DiaryID:  diaries[i].ID,
-		})
-	}
-	photosJSON, err := json.Marshal(photos)
-	if err != nil {
-		log.Printf("ERROR: failed to marshal photos JSON: %v", err)
-		s.renderError(w, http.StatusInternalServerError)
-		return
-	}
-
-	data := map[string]interface{}{
-		"Diaries":       diaries,
-		"From":          fromStr,
-		"To":            toStr,
-		"PhotosJSON":    template.JS(photosJSON),
-		"FilterBaseURL": "/slideshow",
-	}
-
-	if err := s.templates.ExecuteTemplate(w, "slideshow.html", data); err != nil {
-		log.Printf("ERROR: failed to render slideshow template: %v", err)
-		s.renderError(w, http.StatusInternalServerError)
-		return
-	}
 }
 
 // handleBookSlideshow は日記帳別スライドショーページを表示する

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -150,7 +150,6 @@
     <header>
         <h1>植物観察日記</h1>
         <nav>
-            <a href="/slideshow">スライドショー</a>
             {{if .LoggedIn}}
             <a href="/books">日記帳管理</a>
             <span class="user-info">{{.Username}}</span>


### PR DESCRIPTION
## 概要

Issue #138 の対応として、`GET /slideshow`（全日記帳横断スライドショー）を廃止します。
日記帳別スライドショー（`GET /books/{id}/slideshow`）が整備されたため、全横断スライドショーは不要となりました。

## 変更内容

- `app/server.go`: `GET /slideshow` ルートおよび `handleSlideshow` ハンドラを削除
- `app/repository.go`: `DiaryRepository` インターフェースの `GetDiariesAsc` メソッド定義、`MockDiaryRepository.GetDiariesAsc` モック実装を削除
- `app/db.go`: `SQLiteDiaryRepository.GetDiariesAsc` 実装を削除
- `app/templates/index.html`: ヘッダーの「スライドショー」リンクを削除

## 影響範囲

- DBスキーマ変更なし（既存データへの影響なし）
- `/slideshow` に直接アクセスした場合は 404 になる
- `GET /books/{id}/slideshow` および `handleBookSlideshow` は継続して使用

Closes #138