### PR TITLE
#144 日記の編集を日記帳作成者のみに制限する

### DIFF
--- a/app/db.go
+++ b/app/db.go
@@ -139,8 +139,8 @@ func (r *SQLiteDiaryRepository) GetAllDiaries() ([]Diary, error) {
 // GetDiaryByID は指定IDの日記を返す。見つからない場合はnilを返す
 func (r *SQLiteDiaryRepository) GetDiaryByID(id int) (*Diary, error) {
 	var d Diary
-	err := r.db.QueryRow("SELECT id, image_path, content, created_at FROM diary WHERE id = ?", id).
-		Scan(&d.ID, &d.ImagePath, &d.Content, &d.CreatedAt)
+	err := r.db.QueryRow("SELECT id, image_path, content, created_at, book_id FROM diary WHERE id = ?", id).
+		Scan(&d.ID, &d.ImagePath, &d.Content, &d.CreatedAt, &d.BookID)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}

--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -4,17 +4,28 @@ package main
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 // setupE2EServer はE2Eテスト用のHTTPサーバーを設定して起動する
 func setupE2EServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	ts, _ := setupE2EServerWithDB(t)
+	return ts
+}
+
+// setupE2EServerWithDB はE2Eテスト用のHTTPサーバーとDBを設定して起動する
+func setupE2EServerWithDB(t *testing.T) (*httptest.Server, *sql.DB) {
 	t.Helper()
 
 	db := setupTestDB(t)
@@ -31,7 +42,31 @@ func setupE2EServer(t *testing.T) *httptest.Server {
 
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
-	return ts
+	return ts, db
+}
+
+// loginAsUser はユーザーでログインしてセッションCookieを返す
+func loginAsUser(t *testing.T, ts *httptest.Server, username, password string) []*http.Cookie {
+	t.Helper()
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	formData := url.Values{}
+	formData.Set("username", username)
+	formData.Set("password", password)
+	resp, err := client.PostForm(ts.URL+"/login", formData)
+	if err != nil {
+		t.Fatalf("POST /login failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("login failed with status %d", resp.StatusCode)
+	}
+	return resp.Cookies()
 }
 
 // TestE2E_GetIndex はGET /がHTMLを返すことを検証する
@@ -318,5 +353,137 @@ func TestE2E_PostApiPhotos_Unauthorized(t *testing.T) {
 
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("expected status 401, got %d", resp.StatusCode)
+	}
+}
+
+// setupDiaryForOwner はオーナーユーザーと日記帳・日記を作成してdiaryIDを返す
+func setupDiaryForOwner(t *testing.T, ts *httptest.Server, db *sql.DB, ownerUsername, otherUsername string) int {
+	t.Helper()
+
+	// ユーザーを作成
+	for _, username := range []string{ownerUsername, otherUsername} {
+		body := fmt.Sprintf(`{"username": %q, "password": "password"}`, username)
+		resp, err := http.Post(ts.URL+"/api/users", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST /api/users failed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("user creation failed with status %d", resp.StatusCode)
+		}
+	}
+
+	// オーナーユーザーを取得
+	userRepo := NewSQLiteUserRepository(db)
+	ownerUser, err := userRepo.GetUserByUsername(ownerUsername)
+	if err != nil || ownerUser == nil {
+		t.Fatalf("failed to get owner user: %v", err)
+	}
+
+	// 日記帳を作成
+	bookRepo := NewSQLiteBookRepository(db)
+	book, err := bookRepo.CreateBook(ownerUser.ID, "Test Book")
+	if err != nil {
+		t.Fatalf("failed to create book: %v", err)
+	}
+
+	// 日記を作成
+	diaryRepo := NewSQLiteDiaryRepository(db)
+	if err := diaryRepo.CreateDiaryForBook(book.ID, ownerUser.ID, "/photos/test.jpg", "テスト日記", time.Now()); err != nil {
+		t.Fatalf("failed to create diary: %v", err)
+	}
+
+	// 日記IDを取得
+	diaries, err := diaryRepo.GetDiariesByBookID(book.ID)
+	if err != nil || len(diaries) == 0 {
+		t.Fatalf("failed to get diaries: %v", err)
+	}
+	return diaries[0].ID
+}
+
+// TestE2E_DiaryEdit_OwnerCanEdit は日記帳作成者が日記を編集できることを検証する
+func TestE2E_DiaryEdit_OwnerCanEdit(t *testing.T) {
+	ts, db := setupE2EServerWithDB(t)
+
+	diaryID := setupDiaryForOwner(t, ts, db, "owner", "other")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	cookies := loginAsUser(t, ts, "owner", "password")
+
+	// GET /diary/{id}/edit が200を返すことを確認
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/diary/%d/edit", ts.URL, diaryID), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /diary/{id}/edit failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200 for owner, got %d", resp.StatusCode)
+	}
+}
+
+// TestE2E_DiaryEdit_NonOwnerForbidden は日記帳作成者以外が編集できないことを検証する
+func TestE2E_DiaryEdit_NonOwnerForbidden(t *testing.T) {
+	ts, db := setupE2EServerWithDB(t)
+
+	diaryID := setupDiaryForOwner(t, ts, db, "owner", "other")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	cookies := loginAsUser(t, ts, "other", "password")
+
+	// GET /diary/{id}/edit が403を返すことを確認
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/diary/%d/edit", ts.URL, diaryID), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /diary/{id}/edit failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected status 403 for non-owner, got %d", resp.StatusCode)
+	}
+
+	// POST /diary/{id}/edit が403を返すことを確認
+	formData := url.Values{}
+	formData.Set("content", "改ざんされた内容")
+	postReq, err := http.NewRequest("POST", fmt.Sprintf("%s/diary/%d/edit", ts.URL, diaryID), strings.NewReader(formData.Encode()))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		postReq.AddCookie(c)
+	}
+	postResp, err := client.Do(postReq)
+	if err != nil {
+		t.Fatalf("POST /diary/{id}/edit failed: %v", err)
+	}
+	postResp.Body.Close()
+
+	if postResp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected status 403 for non-owner POST, got %d", postResp.StatusCode)
 	}
 }

--- a/app/repository.go
+++ b/app/repository.go
@@ -20,6 +20,7 @@ type Diary struct {
 	ImagePath string
 	Content   string
 	CreatedAt time.Time
+	BookID    *int
 }
 
 // Book は日記帳を表す構造体
@@ -175,11 +176,13 @@ func (r *MockDiaryRepository) CreateDiaryForBook(bookID, creatorID int, imagePat
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	bookIDCopy := bookID
 	diary := &Diary{
 		ID:        r.nextID,
 		ImagePath: imagePath,
 		Content:   content,
 		CreatedAt: createdAt,
+		BookID:    &bookIDCopy,
 	}
 	r.diaries[r.nextID] = diary
 	r.bookDiaries[bookID] = append(r.bookDiaries[bookID], r.nextID)

--- a/app/server.go
+++ b/app/server.go
@@ -286,14 +286,27 @@ func (s *Server) handleDiary(w http.ResponseWriter, r *http.Request) {
 
 	loggedIn := currentUser != nil
 	username := ""
+	isOwner := false
 	if currentUser != nil {
 		username = currentUser.Username
+		if diary.BookID != nil {
+			book, err := s.bookRepo.GetBookByID(*diary.BookID)
+			if err != nil {
+				log.Printf("ERROR: failed to get book %d: %v", *diary.BookID, err)
+				s.renderError(w, http.StatusInternalServerError)
+				return
+			}
+			if book != nil {
+				isOwner = book.CreatorID == currentUser.ID
+			}
+		}
 	}
 
 	data := map[string]interface{}{
 		"Diary":    &diaryView,
 		"LoggedIn": loggedIn,
 		"Username": username,
+		"IsOwner":  isOwner,
 	}
 
 	if err := s.templates.ExecuteTemplate(w, "detail.html", data); err != nil {
@@ -331,15 +344,26 @@ func (s *Server) handleDiaryEditGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	username := ""
-	if currentUser != nil {
-		username = currentUser.Username
+	// 日記帳の作成者チェック
+	if diary.BookID == nil {
+		s.renderError(w, http.StatusForbidden)
+		return
+	}
+	book, err := s.bookRepo.GetBookByID(*diary.BookID)
+	if err != nil {
+		log.Printf("ERROR: failed to get book %d: %v", *diary.BookID, err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+	if book == nil || currentUser == nil || book.CreatorID != currentUser.ID {
+		s.renderError(w, http.StatusForbidden)
+		return
 	}
 
 	data := map[string]interface{}{
 		"Diary":    diary,
 		"LoggedIn": true,
-		"Username": username,
+		"Username": currentUser.Username,
 	}
 
 	if err := s.templates.ExecuteTemplate(w, "edit.html", data); err != nil {
@@ -373,6 +397,29 @@ func (s *Server) handleDiaryEditPost(w http.ResponseWriter, r *http.Request) {
 	}
 	if diary == nil {
 		s.renderError(w, http.StatusNotFound)
+		return
+	}
+
+	currentUser, err := s.getCurrentUser(r)
+	if err != nil {
+		log.Printf("ERROR: failed to get current user: %v", err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+
+	// 日記帳の作成者チェック
+	if diary.BookID == nil {
+		s.renderError(w, http.StatusForbidden)
+		return
+	}
+	book, err := s.bookRepo.GetBookByID(*diary.BookID)
+	if err != nil {
+		log.Printf("ERROR: failed to get book %d: %v", *diary.BookID, err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+	if book == nil || currentUser == nil || book.CreatorID != currentUser.ID {
+		s.renderError(w, http.StatusForbidden)
 		return
 	}
 

--- a/app/templates/detail.html
+++ b/app/templates/detail.html
@@ -160,7 +160,7 @@
         <img class="detail-image" src="/photos/{{.Diary.ImagePath}}" alt="植物の写真">
         <p class="detail-meta">{{(.Diary.CreatedAt | toJST).Format "2006年1月2日"}}（{{.Diary.CreatedAt | toJST | weekdayJP}}）{{(.Diary.CreatedAt | toJST).Format "15:04"}}</p>
         <div class="detail-content">{{.Diary.Content}}</div>
-        {{if .LoggedIn}}
+        {{if .IsOwner}}
         <a href="/diary/{{.Diary.ID}}/edit" class="edit-link">編集</a>
         {{end}}
     </main>


### PR DESCRIPTION
## 概要

日記の編集操作を、その日記が属する日記帳の作成者（`books.creator_id`）のみに制限します。

Closes #144

## 変更内容

### サーバーサイド（`app/server.go`）

- `handleDiaryEditGet`: 日記帳の`creator_id`とログインユーザーのIDを比較し、一致しない場合は403を返す
- `handleDiaryEditPost`: 同様の権限チェックを追加
- `handleDiary`: テンプレートに`IsOwner`フラグを追加（日記帳作成者かどうかの判定）

### データモデル（`app/repository.go`、`app/db.go`）

- `Diary`構造体に`BookID *int`フィールドを追加
- `GetDiaryByID`のSQLクエリに`book_id`を含めるよう変更
- `MockDiaryRepository.CreateDiaryForBook`でDiaryに`BookID`を設定するよう修正

### テンプレート（`app/templates/detail.html`）

- 編集ボタンの表示条件を`{{if .LoggedIn}}`から`{{if .IsOwner}}`に変更

### テスト（`app/e2e_test.go`）

- `setupE2EServerWithDB`: DBにもアクセスできるセットアップ関数を追加
- `loginAsUser`: ログインヘルパー関数を追加
- `TestE2E_DiaryEdit_OwnerCanEdit`: 日記帳作成者が編集できることを検証
- `TestE2E_DiaryEdit_NonOwnerForbidden`: 非オーナーがGET/POST両方で403を受けることを検証

## テスト

```
go test -tags=e2e ./... -count=1
```

全テストパス確認済み