### PR TITLE
#146 日記生成時にGeminiへ渡す過去日記を同じ日記帳のものだけにフィルタリング

### DIFF
--- a/app/db.go
+++ b/app/db.go
@@ -597,9 +597,9 @@ func (r *SQLiteDiaryRepository) GetDiariesByBookIDAsc(bookID int, from, to time.
 	return diaries, nil
 }
 
-// GetDiariesInDateRange は指定日付範囲内の日記を古い順（created_at ASC）で返す
-func (r *SQLiteDiaryRepository) GetDiariesInDateRange(startDate, endDate time.Time) ([]Diary, error) {
-	rows, err := r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE created_at >= ? AND created_at <= ? ORDER BY created_at ASC", startDate, endDate)
+// GetDiariesInDateRange は指定日記帳・日付範囲内の日記を古い順（created_at ASC）で返す
+func (r *SQLiteDiaryRepository) GetDiariesInDateRange(bookID int, startDate, endDate time.Time) ([]Diary, error) {
+	rows, err := r.db.Query("SELECT id, image_path, content, created_at FROM diary WHERE book_id = ? AND created_at >= ? AND created_at <= ? ORDER BY created_at ASC", bookID, startDate, endDate)
 	if err != nil {
 		return nil, err
 	}

--- a/app/db_test.go
+++ b/app/db_test.go
@@ -317,44 +317,60 @@ func TestSQLiteDiaryRepository_GetLatestDiaryCreatedAt(t *testing.T) {
 
 func TestSQLiteDiaryRepository_GetDiariesInDateRange(t *testing.T) {
 	db := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	bookRepo := NewSQLiteBookRepository(db)
 	repo := NewSQLiteDiaryRepository(db)
 
-	// 複数の日記を作成
+	// ユーザーと日記帳を作成
+	if err := userRepo.CreateUser("uuid-001", "alice", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	alice, err := userRepo.GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+	book1, err := bookRepo.CreateBook(alice.ID, "Book 1")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+	book2, err := bookRepo.CreateBook(alice.ID, "Book 2")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+
+	// 複数の日記を日記帳1に作成
 	time1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
 	time2 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	time3 := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
 	time4 := time.Date(2026, 2, 10, 10, 0, 0, 0, time.UTC)
 
-	err := repo.CreateDiary("/path/1.jpg", "日記1", time1)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
+	if err := repo.CreateDiaryForBook(book1.ID, alice.ID, "/path/1.jpg", "日記1", time1); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(book1.ID, alice.ID, "/path/2.jpg", "日記2", time2); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(book1.ID, alice.ID, "/path/3.jpg", "日記3", time3); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(book1.ID, alice.ID, "/path/4.jpg", "日記4", time4); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	// 日記帳2にも日記を作成（フィルタリングの確認用）
+	if err := repo.CreateDiaryForBook(book2.ID, alice.ID, "/path/5.jpg", "日記5", time2); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
 	}
 
-	err = repo.CreateDiary("/path/2.jpg", "日記2", time2)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
-	}
-
-	err = repo.CreateDiary("/path/3.jpg", "日記3", time3)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
-	}
-
-	err = repo.CreateDiary("/path/4.jpg", "日記4", time4)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
-	}
-
-	// 日付範囲内の日記を取得
+	// 日付範囲内の日記を取得（日記帳1のみ）
 	startDate := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2026, 2, 5, 0, 0, 0, 0, time.UTC)
 
-	diaries, err := repo.GetDiariesInDateRange(startDate, endDate)
+	diaries, err := repo.GetDiariesInDateRange(book1.ID, startDate, endDate)
 	if err != nil {
 		t.Fatalf("GetDiariesInDateRange failed: %v", err)
 	}
 
-	// 2件（日記2と日記3）が取得されることを確認
+	// 2件（日記2と日記3）が取得されることを確認（日記帳2の日記5は含まれない）
 	if len(diaries) != 2 {
 		t.Fatalf("expected 2 diaries, got %d", len(diaries))
 	}
@@ -475,20 +491,34 @@ func TestSQLiteDiaryRepository_SearchDiaries(t *testing.T) {
 
 func TestSQLiteDiaryRepository_GetDiariesInDateRange_Empty(t *testing.T) {
 	db := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	bookRepo := NewSQLiteBookRepository(db)
 	repo := NewSQLiteDiaryRepository(db)
+
+	// ユーザーと日記帳を作成
+	if err := userRepo.CreateUser("uuid-001", "alice", "hash"); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	alice, err := userRepo.GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername failed: %v", err)
+	}
+	book, err := bookRepo.CreateBook(alice.ID, "Book 1")
+	if err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
 
 	// 日記を1件作成
 	time1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
-	err := repo.CreateDiary("/path/1.jpg", "日記1", time1)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
+	if err := repo.CreateDiaryForBook(book.ID, alice.ID, "/path/1.jpg", "日記1", time1); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
 	}
 
 	// 範囲外の日付で検索
 	startDate := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2026, 2, 28, 0, 0, 0, 0, time.UTC)
 
-	diaries, err := repo.GetDiariesInDateRange(startDate, endDate)
+	diaries, err := repo.GetDiariesInDateRange(book.ID, startDate, endDate)
 	if err != nil {
 		t.Fatalf("GetDiariesInDateRange failed: %v", err)
 	}

--- a/app/repository.go
+++ b/app/repository.go
@@ -94,7 +94,7 @@ type DiaryRepository interface {
 	UpdateDiaryContent(id int, content string) error
 	IsImageProcessed(imagePath string) (bool, error)
 	GetLatestDiaryCreatedAt() (time.Time, error)
-	GetDiariesInDateRange(startDate, endDate time.Time) ([]Diary, error)
+	GetDiariesInDateRange(bookID int, startDate, endDate time.Time) ([]Diary, error)
 	GetAvailableYearMonths() ([]YearMonth, error)
 	SearchDiaries(keyword string) ([]Diary, error)
 	GetDiariesByBookIDAsc(bookID int, from, to time.Time) ([]Diary, error)
@@ -338,27 +338,30 @@ func (r *MockDiaryRepository) GetDiariesByBookIDAsc(bookID int, from, to time.Ti
 	return result, nil
 }
 
-// GetDiariesInDateRange は指定日付範囲内の日記を古い順で返す
-func (r *MockDiaryRepository) GetDiariesInDateRange(startDate, endDate time.Time) ([]Diary, error) {
+// GetDiariesInDateRange は指定日記帳・日付範囲内の日記を古い順で返す
+func (r *MockDiaryRepository) GetDiariesInDateRange(bookID int, startDate, endDate time.Time) ([]Diary, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	diaryIDs, ok := r.bookDiaries[bookID]
+	if !ok {
+		return []Diary{}, nil
+	}
+
 	result := make([]Diary, 0)
-	for _, d := range r.diaries {
-		if (d.CreatedAt.Equal(startDate) || d.CreatedAt.After(startDate)) &&
-			(d.CreatedAt.Equal(endDate) || d.CreatedAt.Before(endDate)) {
-			result = append(result, *d)
+	for _, id := range diaryIDs {
+		if d, ok := r.diaries[id]; ok {
+			if (d.CreatedAt.Equal(startDate) || d.CreatedAt.After(startDate)) &&
+				(d.CreatedAt.Equal(endDate) || d.CreatedAt.Before(endDate)) {
+				result = append(result, *d)
+			}
 		}
 	}
 
 	// 古い順（CreatedAt昇順）でソート
-	for i := 0; i < len(result); i++ {
-		for j := i + 1; j < len(result); j++ {
-			if result[j].CreatedAt.Before(result[i].CreatedAt) {
-				result[i], result[j] = result[j], result[i]
-			}
-		}
-	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].CreatedAt.Before(result[j].CreatedAt)
+	})
 
 	return result, nil
 }

--- a/app/repository_test.go
+++ b/app/repository_test.go
@@ -314,42 +314,39 @@ func TestMockDiaryRepository_IsImageProcessed(t *testing.T) {
 func TestMockDiaryRepository_GetDiariesInDateRange(t *testing.T) {
 	repo := NewMockDiaryRepository()
 
-	// 複数の日記を作成
+	// 複数の日記を日記帳1に作成
 	time1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
 	time2 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	time3 := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
 	time4 := time.Date(2026, 2, 10, 10, 0, 0, 0, time.UTC)
 
-	err := repo.CreateDiary("/path/1.jpg", "日記1", time1)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
+	if err := repo.CreateDiaryForBook(1, 100, "/path/1.jpg", "日記1", time1); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(1, 100, "/path/2.jpg", "日記2", time2); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(1, 100, "/path/3.jpg", "日記3", time3); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	if err := repo.CreateDiaryForBook(1, 100, "/path/4.jpg", "日記4", time4); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
+	}
+	// 日記帳2にも日記を作成（フィルタリングの確認用）
+	if err := repo.CreateDiaryForBook(2, 100, "/path/5.jpg", "日記5", time2); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
 	}
 
-	err = repo.CreateDiary("/path/2.jpg", "日記2", time2)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
-	}
-
-	err = repo.CreateDiary("/path/3.jpg", "日記3", time3)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
-	}
-
-	err = repo.CreateDiary("/path/4.jpg", "日記4", time4)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
-	}
-
-	// 日付範囲内の日記を取得
+	// 日付範囲内の日記を取得（日記帳1のみ）
 	startDate := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2026, 2, 5, 0, 0, 0, 0, time.UTC)
 
-	diaries, err := repo.GetDiariesInDateRange(startDate, endDate)
+	diaries, err := repo.GetDiariesInDateRange(1, startDate, endDate)
 	if err != nil {
 		t.Fatalf("GetDiariesInDateRange failed: %v", err)
 	}
 
-	// 2件（日記2と日記3）が取得されることを確認
+	// 2件（日記2と日記3）が取得されることを確認（日記帳2の日記5は含まれない）
 	if len(diaries) != 2 {
 		t.Fatalf("expected 2 diaries, got %d", len(diaries))
 	}
@@ -478,18 +475,17 @@ func TestMockDiaryRepository_SearchDiaries(t *testing.T) {
 func TestMockDiaryRepository_GetDiariesInDateRange_Empty(t *testing.T) {
 	repo := NewMockDiaryRepository()
 
-	// 日記を1件作成
+	// 日記を1件作成（日記帳1）
 	time1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
-	err := repo.CreateDiary("/path/1.jpg", "日記1", time1)
-	if err != nil {
-		t.Fatalf("CreateDiary failed: %v", err)
+	if err := repo.CreateDiaryForBook(1, 100, "/path/1.jpg", "日記1", time1); err != nil {
+		t.Fatalf("CreateDiaryForBook failed: %v", err)
 	}
 
 	// 範囲外の日付で検索
 	startDate := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2026, 2, 28, 0, 0, 0, 0, time.UTC)
 
-	diaries, err := repo.GetDiariesInDateRange(startDate, endDate)
+	diaries, err := repo.GetDiariesInDateRange(1, startDate, endDate)
 	if err != nil {
 		t.Fatalf("GetDiariesInDateRange failed: %v", err)
 	}

--- a/app/server.go
+++ b/app/server.go
@@ -645,7 +645,7 @@ func (s *Server) PostApiPhotos(w http.ResponseWriter, r *http.Request) {
 		startOfDay := time.Date(capturedAt.Year(), capturedAt.Month(), capturedAt.Day(), 0, 0, 0, 0, capturedAt.Location())
 		oneMonthAgo := startOfDay.AddDate(0, -1, 0)
 		endOfPrevDay := startOfDay.Add(-time.Nanosecond)
-		pastDiaries, err := s.repo.GetDiariesInDateRange(oneMonthAgo, endOfPrevDay)
+		pastDiaries, err := s.repo.GetDiariesInDateRange(book.ID, oneMonthAgo, endOfPrevDay)
 		if err != nil {
 			log.Printf("WARN: failed to get past diaries for %s: %v, continuing with empty history", imagePath, err)
 			pastDiaries = []Diary{}


### PR DESCRIPTION
## 概要

日記生成時にGeminiへ渡す過去日記を、同じ日記帳のものだけにフィルタリングするよう修正しました。

## 変更内容

- `GetDiariesInDateRange` インターフェースに `bookID` パラメータを追加
- `SQLiteDiaryRepository.GetDiariesInDateRange` の SQL に `AND book_id = ?` を追加し、日記帳でフィルタリング
- `MockDiaryRepository.GetDiariesInDateRange` でも同様に bookID フィルタリングを実装
- `PostApiPhotos` ハンドラで `GetDiariesInDateRange` 呼び出し時に `book.ID` を渡すよう修正
- 各テストを bookID フィルタリングに対応するよう更新（別の日記帳の日記が混入しないことも検証）

## テスト

全ユニットテストが通過しています。

Closes #146