### PR TITLE
#155 000006 normalize_image_path の DOWN マイグレーションを改善する

### DIFF
--- a/app/migrations/000006_normalize_image_path.down.sql
+++ b/app/migrations/000006_normalize_image_path.down.sql
@@ -1,4 +1,6 @@
--- このマイグレーションはデータの正規化であり、ロールバックは安全に行えない。
--- image_path の旧形式（data/photos/ プレフィックス付き）と新形式を区別する情報がDBに存在しないため、
--- 元の状態に戻すことができない。
-SELECT 1;
+-- diary.image_path に 'data/photos/' プレフィックスを付与して旧形式に戻す
+-- NOT LIKE 条件により、すでにプレフィックスが付いている行への二重付与を防ぐ
+-- 注意: migration 006 適用前から新形式で保存されていた行にも誤ってプレフィックスが付与される可能性がある
+UPDATE diary
+SET image_path = 'data/photos/' || image_path
+WHERE image_path NOT LIKE 'data/photos/%';


### PR DESCRIPTION
## 概要

`000006_normalize_image_path.down.sql` が `SELECT 1` のみの no-op になっていたため、UP マイグレーション適用後にロールバックしてもデータが新形式のまま残り続ける問題を修正しました。

DOWN マイグレーションに `data/photos/` プレフィックスを再付与する UPDATE 文を実装することで、実用上 UP マイグレーション前の状態に近づけられるようになります。

## 関連Issue

Fixes: #155

## 修正内容

- `app/migrations/000006_normalize_image_path.down.sql` を改善
  - `SELECT 1`（no-op）から実際のロールバック処理に変更
  - `image_path NOT LIKE 'data/photos/%'` 条件により二重プレフィックス付与を防止
  - 制限事項（migration 006 適用前から新形式で保存されていた行に誤ってプレフィックスが付与される可能性）をコメントに記載

## その他

Issueに記載の通り、migration 006 適用前からすでに新形式（プレフィックスなし）で保存されていた行が存在する場合、DOWN 適用後にそれらの行に誤ってプレフィックスが付与されるリスクがあります。ただし実運用上このリスクは低く、no-op のままにしておくよりも有用な改善と判断しています。

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)