### PR TITLE
#167 スライドショーのループ再生切り替えをボタンからチェックボックスに変更

### DIFF
--- a/templates/slideshow.html
+++ b/templates/slideshow.html
@@ -154,14 +154,19 @@
             cursor: not-allowed;
         }
 
-        .slideshow-controls button.loop-off {
-            background-color: #ffffff;
-            color: #4a7c59;
-            border: 2px solid #4a7c59;
+        .loop-control {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 0.95rem;
+            cursor: pointer;
         }
 
-        .slideshow-controls button.loop-off:hover {
-            background-color: #f0f7f2;
+        .loop-control input[type="checkbox"] {
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+            accent-color: #4a7c59;
         }
 
         .speed-control {
@@ -263,7 +268,10 @@
                         <option value="5000">5秒</option>
                     </select>
                 </div>
-                <button id="btn-loop" onclick="toggleLoop()">ループ: ON</button>
+                <div class="loop-control">
+                    <input type="checkbox" id="chk-loop" checked onchange="toggleLoop()">
+                    <label for="chk-loop">ループ再生</label>
+                </div>
             </div>
         </div>
         <script>
@@ -308,15 +316,7 @@
             }
 
             function toggleLoop() {
-                loopEnabled = !loopEnabled;
-                var btn = document.getElementById('btn-loop');
-                if (loopEnabled) {
-                    btn.textContent = 'ループ: ON';
-                    btn.classList.remove('loop-off');
-                } else {
-                    btn.textContent = 'ループ: OFF';
-                    btn.classList.add('loop-off');
-                }
+                loopEnabled = document.getElementById('chk-loop').checked;
             }
 
             function togglePlay() {


### PR DESCRIPTION
## 概要

スライドショー画面のループ再生切り替えUIをボタンからチェックボックスに変更しました。

## 変更内容

- `<button id="btn-loop">` を `<input type="checkbox" id="chk-loop">` + `<label>` に置き換え
- ラベルテキストを「ループ再生」に設定
- 初期状態はチェックあり（ループ有効）を維持
- `toggleLoop()` 関数をチェックボックスの状態を直接読み取るよう簡略化
- `.loop-off` ボタン用CSSを削除し、`.loop-control` チェックボックス用スタイルを追加

## 効果

チェックボックスは「チェックが入っている＝有効」という一般的なUIの慣習があるため、現在の状態が一目で分かりやすくなりました。

Closes #167