### PR TITLE
#169 日記ページのヘッダースタイルをトップページに合わせる

### DIFF
--- a/templates/detail.html
+++ b/templates/detail.html
@@ -19,49 +19,62 @@
         }
 
         header {
-            border-bottom: 1px solid #e0e0e0;
+            background-color: #4a7c59;
+            color: #ffffff;
             padding: 16px 24px;
             display: flex;
             align-items: center;
-            justify-content: space-between;
+            gap: 24px;
         }
 
-        header a {
-            color: #333333;
-            text-decoration: none;
-            font-size: 1.25rem;
+        header h1 {
+            font-size: 1.5rem;
             font-weight: bold;
+        }
+
+        header h1 a {
+            color: #ffffff;
+            text-decoration: none;
         }
 
         header nav {
             display: flex;
             align-items: center;
-            gap: 12px;
+            gap: 16px;
+            margin-left: auto;
         }
 
         header nav a {
-            color: #557a3e;
-            font-size: 0.9rem;
+            color: #ffffff;
+            text-decoration: none;
+            font-size: 0.95rem;
+            opacity: 0.85;
+        }
+
+        header nav a:hover {
+            opacity: 1;
+            text-decoration: underline;
         }
 
         header nav .user-info {
             font-size: 0.9rem;
-            color: #555555;
+            opacity: 0.85;
         }
 
         header nav .logout-btn {
             background: none;
-            border: 1px solid #ccc;
+            border: 1px solid rgba(255, 255, 255, 0.6);
             border-radius: 4px;
-            color: #555555;
+            color: #ffffff;
             cursor: pointer;
             font-size: 0.9rem;
+            opacity: 0.85;
             padding: 4px 10px;
         }
 
         header nav .logout-btn:hover {
-            border-color: #557a3e;
-            color: #557a3e;
+            opacity: 1;
+            background-color: rgba(255, 255, 255, 0.15);
         }
 
         .back-link {
@@ -121,6 +134,13 @@
         @media (max-width: 600px) {
             header {
                 padding: 12px 16px;
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 4px;
+            }
+
+            header h1 {
+                font-size: 1.25rem;
             }
 
             .back-link {
@@ -143,7 +163,7 @@
 </head>
 <body>
     <header>
-        <a href="/">植物日記</a>
+        <h1><a href="/">植物日記</a></h1>
         <nav>
             {{if .LoggedIn}}
             <span class="user-info">{{.Username}}</span>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -19,49 +19,62 @@
         }
 
         header {
-            border-bottom: 1px solid #e0e0e0;
+            background-color: #4a7c59;
+            color: #ffffff;
             padding: 16px 24px;
             display: flex;
             align-items: center;
-            justify-content: space-between;
+            gap: 24px;
         }
 
-        header a {
-            color: #333333;
-            text-decoration: none;
-            font-size: 1.25rem;
+        header h1 {
+            font-size: 1.5rem;
             font-weight: bold;
+        }
+
+        header h1 a {
+            color: #ffffff;
+            text-decoration: none;
         }
 
         header nav {
             display: flex;
             align-items: center;
-            gap: 12px;
+            gap: 16px;
+            margin-left: auto;
         }
 
         header nav a {
-            color: #557a3e;
-            font-size: 0.9rem;
+            color: #ffffff;
+            text-decoration: none;
+            font-size: 0.95rem;
+            opacity: 0.85;
+        }
+
+        header nav a:hover {
+            opacity: 1;
+            text-decoration: underline;
         }
 
         header nav .user-info {
             font-size: 0.9rem;
-            color: #555555;
+            opacity: 0.85;
         }
 
         header nav .logout-btn {
             background: none;
-            border: 1px solid #ccc;
+            border: 1px solid rgba(255, 255, 255, 0.6);
             border-radius: 4px;
-            color: #555555;
+            color: #ffffff;
             cursor: pointer;
             font-size: 0.9rem;
+            opacity: 0.85;
             padding: 4px 10px;
         }
 
         header nav .logout-btn:hover {
-            border-color: #557a3e;
-            color: #557a3e;
+            opacity: 1;
+            background-color: rgba(255, 255, 255, 0.15);
         }
 
         .back-link {
@@ -148,6 +161,13 @@
         @media (max-width: 600px) {
             header {
                 padding: 12px 16px;
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 4px;
+            }
+
+            header h1 {
+                font-size: 1.25rem;
             }
 
             .back-link {
@@ -162,7 +182,7 @@
 </head>
 <body>
     <header>
-        <a href="/">植物日記</a>
+        <h1><a href="/">植物日記</a></h1>
         <nav>
             <span class="user-info">{{.Username}}</span>
             <form method="POST" action="/logout" style="display:inline">


### PR DESCRIPTION
## 概要

`detail.html`と`edit.html`のヘッダースタイルが他ページと異なっていたため、トップページ（`index.html`）に合わせてスタイルを統一しました。

## 関連Issue

Fixes: #169

## 修正内容

### `templates/detail.html`, `templates/edit.html` 共通

**CSSの変更:**
- `header`に`background-color: #4a7c59`と`color: #ffffff`を追加（緑背景・白文字）
- `header`の`border-bottom: 1px solid #e0e0e0`を削除
- `header`の`justify-content: space-between`を削除し`gap: 24px`を追加
- `header a` → `header h1` + `header h1 a` に変更し、フォントサイズを`1.5rem`に統一
- `header nav`の`gap`を`12px`→`16px`に変更、`margin-left: auto`を追加
- `header nav a`を白文字・`opacity: 0.85`に変更
- `header nav a:hover`を追加（`opacity: 1; text-decoration: underline`）
- `.user-info`の`color: #555555`を削除し`opacity: 0.85`に統一
- `.logout-btn`のボーダーを`rgba(255,255,255,0.6)`、文字色を`#ffffff`に変更
- `.logout-btn:hover`を半透明白背景スタイルに変更
- レスポンシブ対応：`header`に`flex-direction: column; align-items: flex-start; gap: 4px`を追加

**HTMLの変更:**
- ヘッダーのタイトルリンク`<a href="/">植物日記</a>`を`<h1><a href="/">植物日記</a></h1>`に変更

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)