### PR TITLE
#170 日記帳設定ページを新設し、アップロードキーの表示を移動する

### DIFF
--- a/internal/adapter/handler/book.go
+++ b/internal/adapter/handler/book.go
@@ -167,6 +167,50 @@ func (s *Server) handleGetBook(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handleBookSettings は日記帳設定ページを表示する
+func (s *Server) handleBookSettings(w http.ResponseWriter, r *http.Request) {
+	idStr := r.PathValue("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		log.Printf("ERROR: invalid book id: %s", idStr)
+		s.renderError(w, http.StatusNotFound)
+		return
+	}
+
+	book, err := s.bookRepo.GetBookByID(id)
+	if err != nil {
+		log.Printf("ERROR: failed to get book %d: %v", id, err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+	if book == nil {
+		s.renderError(w, http.StatusNotFound)
+		return
+	}
+
+	currentUser, err := s.getCurrentUser(r)
+	if err != nil {
+		log.Printf("ERROR: failed to get current user: %v", err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+
+	if currentUser == nil || currentUser.ID != book.CreatorID {
+		s.renderError(w, http.StatusForbidden)
+		return
+	}
+
+	data := map[string]interface{}{
+		"Book":     book,
+		"Username": currentUser.Username,
+	}
+
+	if err := s.templates.ExecuteTemplate(w, "book_settings.html", data); err != nil {
+		log.Printf("ERROR: failed to render book_settings template for book %d: %v", id, err)
+		s.renderError(w, http.StatusInternalServerError)
+	}
+}
+
 // handleBookSlideshow は日記帳別スライドショーページを表示する
 func (s *Server) handleBookSlideshow(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")

--- a/internal/adapter/handler/server.go
+++ b/internal/adapter/handler/server.go
@@ -79,6 +79,7 @@ func NewServer(repo domain.DiaryRepository, userRepo domain.UserRepository, book
 	s.mux.HandleFunc("GET /books", s.requireLogin(s.handleGetBooks))
 	s.mux.HandleFunc("POST /books", s.requireLogin(s.handlePostBooks))
 	s.mux.HandleFunc("GET /books/{id}", s.handleGetBook)
+	s.mux.HandleFunc("GET /books/{id}/settings", s.requireLogin(s.handleBookSettings))
 	s.mux.HandleFunc("GET /books/{id}/slideshow", s.handleBookSlideshow)
 
 	adapter.HandlerFromMux(s, s.mux)

--- a/templates/book_detail.html
+++ b/templates/book_detail.html
@@ -111,31 +111,16 @@
             margin-bottom: 16px;
         }
 
-        .section-label {
+        .settings-link {
+            display: inline-block;
+            margin-bottom: 16px;
+            color: #4a7c59;
+            text-decoration: none;
             font-size: 0.9rem;
-            color: #555555;
-            margin-bottom: 6px;
         }
 
-        .upload-key-box {
-            background-color: #f5f5f5;
-            border: 1px solid #e0e0e0;
-            border-radius: 6px;
-            padding: 12px 16px;
-            font-family: monospace;
-            font-size: 1rem;
-            word-break: break-all;
-            margin-bottom: 12px;
-        }
-
-        .security-notice {
-            background-color: #fff8e1;
-            border: 1px solid #ffe082;
-            border-radius: 6px;
-            padding: 12px 16px;
-            font-size: 0.85rem;
-            color: #7a6400;
-            margin-bottom: 32px;
+        .settings-link:hover {
+            text-decoration: underline;
         }
 
         .diary-list {
@@ -271,9 +256,7 @@
         {{end}}
 
         {{if .IsOwner}}
-        <p class="section-label">アップロードキー</p>
-        <div class="upload-key-box">{{.Book.UploadKey}}</div>
-        <div class="security-notice">&#x26A0; このキーは外部に公開しないでください。</div>
+        <a class="settings-link" href="/books/{{.Book.ID}}/settings">設定</a>
         {{end}}
 
         {{if .Diaries}}

--- a/templates/book_settings.html
+++ b/templates/book_settings.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>植物観察日記 - 日記帳設定</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: "Hiragino Kaku Gothic ProN", "Noto Sans JP", "Meiryo", sans-serif;
+            background-color: #ffffff;
+            color: #333333;
+            line-height: 1.6;
+        }
+
+        header {
+            background-color: #4a7c59;
+            color: #ffffff;
+            padding: 16px 24px;
+            display: flex;
+            align-items: center;
+            gap: 24px;
+        }
+
+        header h1 {
+            font-size: 1.5rem;
+            font-weight: bold;
+        }
+
+        header h1 a {
+            color: #ffffff;
+            text-decoration: none;
+        }
+
+        header h1 a:hover {
+            text-decoration: underline;
+        }
+
+        header nav {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            margin-left: auto;
+        }
+
+        header nav a {
+            color: #ffffff;
+            text-decoration: none;
+            font-size: 0.95rem;
+            opacity: 0.85;
+        }
+
+        header nav a:hover {
+            opacity: 1;
+            text-decoration: underline;
+        }
+
+        header nav .user-info {
+            font-size: 0.9rem;
+            opacity: 0.85;
+        }
+
+        header nav .logout-btn {
+            background: none;
+            border: 1px solid rgba(255, 255, 255, 0.6);
+            border-radius: 4px;
+            color: #ffffff;
+            cursor: pointer;
+            font-size: 0.9rem;
+            opacity: 0.85;
+            padding: 4px 10px;
+        }
+
+        header nav .logout-btn:hover {
+            opacity: 1;
+            background-color: rgba(255, 255, 255, 0.15);
+        }
+
+        .back-link {
+            display: inline-block;
+            margin: 16px 24px;
+            color: #4a7c59;
+            text-decoration: none;
+            font-size: 0.9rem;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        main {
+            max-width: 960px;
+            margin: 0 auto;
+            padding: 0 24px 48px;
+        }
+
+        .page-title {
+            font-size: 1.5rem;
+            font-weight: bold;
+            margin-bottom: 8px;
+        }
+
+        .book-name {
+            color: #555555;
+            font-size: 1rem;
+            margin-bottom: 24px;
+        }
+
+        .section-label {
+            font-size: 0.9rem;
+            color: #555555;
+            margin-bottom: 6px;
+        }
+
+        .upload-key-box {
+            background-color: #f5f5f5;
+            border: 1px solid #e0e0e0;
+            border-radius: 6px;
+            padding: 12px 16px;
+            font-family: monospace;
+            font-size: 1rem;
+            word-break: break-all;
+            margin-bottom: 12px;
+        }
+
+        .security-notice {
+            background-color: #fff8e1;
+            border: 1px solid #ffe082;
+            border-radius: 6px;
+            padding: 12px 16px;
+            font-size: 0.85rem;
+            color: #7a6400;
+            margin-bottom: 32px;
+        }
+
+        @media screen and (max-width: 640px) {
+            header {
+                padding: 12px 16px;
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 4px;
+            }
+
+            header h1 {
+                font-size: 1.25rem;
+            }
+
+            .back-link {
+                margin: 12px 16px;
+            }
+
+            main {
+                padding: 0 16px 32px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1><a href="/">植物観察日記</a></h1>
+        <nav>
+            <a href="/books">日記帳管理</a>
+            <span class="user-info">{{.Username}}</span>
+            <form method="POST" action="/logout" style="display:inline">
+                <button type="submit" class="logout-btn">ログアウト</button>
+            </form>
+        </nav>
+    </header>
+    <a class="back-link" href="/books/{{.Book.ID}}">&larr; 日記帳詳細へ戻る</a>
+    <main>
+        <p class="page-title">日記帳設定</p>
+        <p class="book-name">{{.Book.Name}}</p>
+
+        <p class="section-label">アップロードキー</p>
+        <div class="upload-key-box">{{.Book.UploadKey}}</div>
+        <div class="security-notice">&#x26A0; このキーは外部に公開しないでください。</div>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## 概要

日記帳ごとの設定画面を新設し、アップロードキーの表示を日記帳詳細ページから設定ページへ移動する。

Closes #170

## 変更内容

- `GET /books/{id}/settings` ルートを追加（`requireLogin` ミドルウェア適用）
- `handleBookSettings` ハンドラーを追加（所有者以外は 403 エラーを表示）
- `templates/book_settings.html` を新規作成（ページタイトル「日記帳設定」、アップロードキー表示、戻るリンク）
- `templates/book_detail.html` からアップロードキー表示を削除し、所有者向けに設定ページへのリンクを追加

## テスト

- `go build ./...` 成功
- `go test ./...` 全テスト通過