### PR TITLE
#173 日記帳の設定画面で名前を変更できるようにする

### DIFF
--- a/internal/adapter/handler/book.go
+++ b/internal/adapter/handler/book.go
@@ -99,6 +99,10 @@ func (s *Server) handlePostBooks(w http.ResponseWriter, r *http.Request) {
 		s.renderError(w, http.StatusBadRequest)
 		return
 	}
+	if len([]rune(name)) > 50 {
+		s.renderError(w, http.StatusBadRequest)
+		return
+	}
 
 	book, err := s.bookRepo.CreateBook(user.ID, name)
 	if err != nil {
@@ -203,12 +207,83 @@ func (s *Server) handleBookSettings(w http.ResponseWriter, r *http.Request) {
 	data := map[string]interface{}{
 		"Book":     book,
 		"Username": currentUser.Username,
+		"FormName": book.Name,
+		"Success":  r.URL.Query().Get("success") == "1",
 	}
 
 	if err := s.templates.ExecuteTemplate(w, "book_settings.html", data); err != nil {
 		log.Printf("ERROR: failed to render book_settings template for book %d: %v", id, err)
 		s.renderError(w, http.StatusInternalServerError)
 	}
+}
+
+// handleBookSettingsPost は日記帳の名前を変更する
+func (s *Server) handleBookSettingsPost(w http.ResponseWriter, r *http.Request) {
+	idStr := r.PathValue("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		log.Printf("ERROR: invalid book id: %s", idStr)
+		s.renderError(w, http.StatusNotFound)
+		return
+	}
+
+	book, err := s.bookRepo.GetBookByID(id)
+	if err != nil {
+		log.Printf("ERROR: failed to get book %d: %v", id, err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+	if book == nil {
+		s.renderError(w, http.StatusNotFound)
+		return
+	}
+
+	currentUser, err := s.getCurrentUser(r)
+	if err != nil {
+		log.Printf("ERROR: failed to get current user: %v", err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+
+	if currentUser == nil || currentUser.ID != book.CreatorID {
+		s.renderError(w, http.StatusForbidden)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		s.renderError(w, http.StatusBadRequest)
+		return
+	}
+	name := r.FormValue("name")
+
+	var errMsg string
+	if name == "" {
+		errMsg = "日記帳名は必須です"
+	} else if len([]rune(name)) > 50 {
+		errMsg = "日記帳名は50文字以内で入力してください"
+	}
+
+	if errMsg != "" {
+		data := map[string]interface{}{
+			"Book":     book,
+			"Username": currentUser.Username,
+			"FormName": name,
+			"Error":    errMsg,
+		}
+		if err := s.templates.ExecuteTemplate(w, "book_settings.html", data); err != nil {
+			log.Printf("ERROR: failed to render book_settings template for book %d: %v", id, err)
+			s.renderError(w, http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if err := s.bookRepo.UpdateBookName(id, name); err != nil {
+		log.Printf("ERROR: failed to update book name for book %d: %v", id, err)
+		s.renderError(w, http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, fmt.Sprintf("/books/%d/settings?success=1", id), http.StatusFound)
 }
 
 // handleBookSlideshow は日記帳別スライドショーページを表示する

--- a/internal/adapter/handler/e2e_test.go
+++ b/internal/adapter/handler/e2e_test.go
@@ -409,6 +409,182 @@ func TestE2E_PostApiPhotos_Unauthorized(t *testing.T) {
 	}
 }
 
+// setupBookForOwner はオーナーユーザーと日記帳を作成してbookIDを返す
+func setupBookForOwner(t *testing.T, ts *httptest.Server, db *sql.DB, ownerUsername, otherUsername string) int {
+	t.Helper()
+
+	// ユーザーを作成
+	for _, username := range []string{ownerUsername, otherUsername} {
+		body := fmt.Sprintf(`{"username": %q, "password": "password"}`, username)
+		resp, err := http.Post(ts.URL+"/api/users", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST /api/users failed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("user creation failed with status %d", resp.StatusCode)
+		}
+	}
+
+	// オーナーユーザーを取得
+	userRepo := sqlite.NewSQLiteUserRepository(db)
+	ownerUser, err := userRepo.GetUserByUsername(ownerUsername)
+	if err != nil || ownerUser == nil {
+		t.Fatalf("failed to get owner user: %v", err)
+	}
+
+	// 日記帳を作成
+	bookRepo := sqlite.NewSQLiteBookRepository(db)
+	book, err := bookRepo.CreateBook(ownerUser.ID, "Test Book")
+	if err != nil {
+		t.Fatalf("failed to create book: %v", err)
+	}
+
+	return book.ID
+}
+
+// TestE2E_BookSettings_UpdateName_Success はオーナーが名前を変更できることを検証する
+func TestE2E_BookSettings_UpdateName_Success(t *testing.T) {
+	ts, db := setupE2EServerWithDB(t)
+
+	bookID := setupBookForOwner(t, ts, db, "owner", "other")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	cookies := loginAsUser(t, ts, "owner", "password")
+
+	formData := url.Values{}
+	formData.Set("name", "新しい日記帳名")
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/books/%d/settings", ts.URL, bookID), strings.NewReader(formData.Encode()))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST /books/{id}/settings failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("expected status 302, got %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	expected := fmt.Sprintf("/books/%d/settings?success=1", bookID)
+	if location != expected {
+		t.Errorf("expected redirect to %s, got %s", expected, location)
+	}
+}
+
+// TestE2E_BookSettings_UpdateName_EmptyName は空文字で送信するとエラーになることを検証する
+func TestE2E_BookSettings_UpdateName_EmptyName(t *testing.T) {
+	ts, db := setupE2EServerWithDB(t)
+
+	bookID := setupBookForOwner(t, ts, db, "owner", "other")
+
+	cookies := loginAsUser(t, ts, "owner", "password")
+
+	formData := url.Values{}
+	formData.Set("name", "")
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/books/%d/settings", ts.URL, bookID), strings.NewReader(formData.Encode()))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /books/{id}/settings failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// バリデーションエラーは設定画面を再表示（200）
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200 for empty name, got %d", resp.StatusCode)
+	}
+}
+
+// TestE2E_BookSettings_UpdateName_TooLongName は51文字以上の名前で送信するとエラーになることを検証する
+func TestE2E_BookSettings_UpdateName_TooLongName(t *testing.T) {
+	ts, db := setupE2EServerWithDB(t)
+
+	bookID := setupBookForOwner(t, ts, db, "owner", "other")
+
+	cookies := loginAsUser(t, ts, "owner", "password")
+
+	// 51文字の名前
+	longName := strings.Repeat("あ", 51)
+	formData := url.Values{}
+	formData.Set("name", longName)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/books/%d/settings", ts.URL, bookID), strings.NewReader(formData.Encode()))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /books/{id}/settings failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// バリデーションエラーは設定画面を再表示（200）
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200 for too long name, got %d", resp.StatusCode)
+	}
+}
+
+// TestE2E_BookSettings_UpdateName_NonOwnerForbidden は非オーナーがPOSTすると403になることを検証する
+func TestE2E_BookSettings_UpdateName_NonOwnerForbidden(t *testing.T) {
+	ts, db := setupE2EServerWithDB(t)
+
+	bookID := setupBookForOwner(t, ts, db, "owner", "other")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	cookies := loginAsUser(t, ts, "other", "password")
+
+	formData := url.Values{}
+	formData.Set("name", "乗っ取り")
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/books/%d/settings", ts.URL, bookID), strings.NewReader(formData.Encode()))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST /books/{id}/settings failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected status 403, got %d", resp.StatusCode)
+	}
+}
+
 // setupDiaryForOwner はオーナーユーザーと日記帳・日記を作成してdiaryIDを返す
 func setupDiaryForOwner(t *testing.T, ts *httptest.Server, db *sql.DB, ownerUsername, otherUsername string) int {
 	t.Helper()

--- a/internal/adapter/handler/server.go
+++ b/internal/adapter/handler/server.go
@@ -80,6 +80,7 @@ func NewServer(repo domain.DiaryRepository, userRepo domain.UserRepository, book
 	s.mux.HandleFunc("POST /books", s.requireLogin(s.handlePostBooks))
 	s.mux.HandleFunc("GET /books/{id}", s.handleGetBook)
 	s.mux.HandleFunc("GET /books/{id}/settings", s.requireLogin(s.handleBookSettings))
+	s.mux.HandleFunc("POST /books/{id}/settings", s.requireLogin(s.handleBookSettingsPost))
 	s.mux.HandleFunc("GET /books/{id}/slideshow", s.handleBookSlideshow)
 
 	adapter.HandlerFromMux(s, s.mux)

--- a/internal/domain/mock.go
+++ b/internal/domain/mock.go
@@ -376,6 +376,19 @@ func (r *MockBookRepository) GetBookByUploadKey(uploadKey string) (*Book, error)
 	return nil, nil
 }
 
+// UpdateBookName は指定IDの日記帳の名前を更新する
+func (r *MockBookRepository) UpdateBookName(id int, name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	b, ok := r.books[id]
+	if !ok {
+		return fmt.Errorf("book %d not found", id)
+	}
+	b.Name = name
+	return nil
+}
+
 // DeleteBook は指定IDの日記帳を削除する
 func (r *MockBookRepository) DeleteBook(id int) error {
 	r.mu.Lock()

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -9,6 +9,7 @@ type BookRepository interface {
 	GetBooksByCreatorID(creatorID int) ([]Book, error)
 	GetBookByID(id int) (*Book, error)
 	GetBookByUploadKey(uploadKey string) (*Book, error)
+	UpdateBookName(id int, name string) error
 	DeleteBook(id int) error
 }
 

--- a/internal/infra/sqlite/book_repository.go
+++ b/internal/infra/sqlite/book_repository.go
@@ -137,6 +137,22 @@ func (r *SQLiteBookRepository) GetBookByUploadKey(uploadKey string) (*domain.Boo
 	return &b, nil
 }
 
+// UpdateBookName は指定IDの日記帳の名前を更新する
+func (r *SQLiteBookRepository) UpdateBookName(id int, name string) error {
+	result, err := r.db.Exec("UPDATE books SET name = ? WHERE id = ?", name, id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("book %d not found", id)
+	}
+	return nil
+}
+
 // DeleteBook は指定IDの日記帳を削除する
 func (r *SQLiteBookRepository) DeleteBook(id int) error {
 	result, err := r.db.Exec("DELETE FROM books WHERE id = ?", id)

--- a/internal/infra/sqlite/migration_test.go
+++ b/internal/infra/sqlite/migration_test.go
@@ -76,7 +76,7 @@ func TestMigrations_AllDown(t *testing.T) {
 func TestMigrations_StepByStep(t *testing.T) {
 	_, m := setupMigrate(t)
 
-	const numMigrations = 6
+	const numMigrations = 8
 
 	// 1ステップずつUpを適用
 	for step := 1; step <= numMigrations; step++ {

--- a/migrations/000008_add_book_name_length_check.down.sql
+++ b/migrations/000008_add_book_name_length_check.down.sql
@@ -1,0 +1,25 @@
+-- 外部キー制約を一時無効化
+PRAGMA foreign_keys = OFF;
+
+-- CHECK制約なしの books_new テーブルを作成
+CREATE TABLE books_new (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    uuid       TEXT NOT NULL UNIQUE,
+    creator_id INTEGER NOT NULL REFERENCES users(id),
+    name       TEXT NOT NULL,
+    upload_key TEXT NOT NULL UNIQUE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 既存データを books から books_new にコピー
+INSERT INTO books_new (id, uuid, creator_id, name, upload_key, created_at)
+SELECT id, uuid, creator_id, name, upload_key, created_at FROM books;
+
+-- 旧 books テーブルを削除
+DROP TABLE books;
+
+-- books_new を books にリネーム
+ALTER TABLE books_new RENAME TO books;
+
+-- 外部キー制約を再有効化
+PRAGMA foreign_keys = ON;

--- a/migrations/000008_add_book_name_length_check.up.sql
+++ b/migrations/000008_add_book_name_length_check.up.sql
@@ -1,0 +1,25 @@
+-- 外部キー制約を一時無効化
+PRAGMA foreign_keys = OFF;
+
+-- CHECK(length(name) <= 50) 付きの books_new テーブルを作成
+CREATE TABLE books_new (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    uuid       TEXT NOT NULL UNIQUE,
+    creator_id INTEGER NOT NULL REFERENCES users(id),
+    name       TEXT NOT NULL CHECK(length(name) <= 50),
+    upload_key TEXT NOT NULL UNIQUE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 既存データを books から books_new にコピー
+INSERT INTO books_new (id, uuid, creator_id, name, upload_key, created_at)
+SELECT id, uuid, creator_id, name, upload_key, created_at FROM books;
+
+-- 旧 books テーブルを削除
+DROP TABLE books;
+
+-- books_new を books にリネーム
+ALTER TABLE books_new RENAME TO books;
+
+-- 外部キー制約を再有効化
+PRAGMA foreign_keys = ON;

--- a/templates/book_settings.html
+++ b/templates/book_settings.html
@@ -102,13 +102,69 @@
         .page-title {
             font-size: 1.5rem;
             font-weight: bold;
-            margin-bottom: 8px;
+            margin-bottom: 24px;
         }
 
-        .book-name {
-            color: #555555;
+        .section-title {
             font-size: 1rem;
+            font-weight: bold;
+            margin-bottom: 8px;
+            margin-top: 32px;
+        }
+
+        .success-message {
+            background-color: #e8f5e9;
+            border: 1px solid #a5d6a7;
+            border-radius: 6px;
+            color: #2e7d32;
+            font-size: 0.9rem;
             margin-bottom: 24px;
+            padding: 12px 16px;
+        }
+
+        .error-message {
+            background-color: #ffebee;
+            border: 1px solid #ef9a9a;
+            border-radius: 6px;
+            color: #c62828;
+            font-size: 0.9rem;
+            margin-bottom: 12px;
+            padding: 12px 16px;
+        }
+
+        .name-form {
+            margin-bottom: 32px;
+        }
+
+        .name-input {
+            border: 1px solid #cccccc;
+            border-radius: 4px;
+            display: block;
+            font-family: inherit;
+            font-size: 1rem;
+            margin-bottom: 12px;
+            padding: 8px 12px;
+            width: 100%;
+            max-width: 400px;
+        }
+
+        .name-input:focus {
+            border-color: #4a7c59;
+            outline: none;
+        }
+
+        .save-btn {
+            background-color: #4a7c59;
+            border: none;
+            border-radius: 4px;
+            color: #ffffff;
+            cursor: pointer;
+            font-size: 0.95rem;
+            padding: 8px 20px;
+        }
+
+        .save-btn:hover {
+            background-color: #3a6347;
         }
 
         .section-label {
@@ -174,8 +230,21 @@
     <a class="back-link" href="/books/{{.Book.ID}}">&larr; 日記帳詳細へ戻る</a>
     <main>
         <p class="page-title">日記帳設定</p>
-        <p class="book-name">{{.Book.Name}}</p>
 
+        {{if .Success}}
+        <div class="success-message">名前を変更しました</div>
+        {{end}}
+
+        <p class="section-title">日記帳名</p>
+        {{if .Error}}
+        <div class="error-message">{{.Error}}</div>
+        {{end}}
+        <form class="name-form" method="POST" action="/books/{{.Book.ID}}/settings">
+            <input class="name-input" type="text" id="name" name="name" value="{{.FormName}}" maxlength="50" required>
+            <button class="save-btn" type="submit">保存</button>
+        </form>
+
+        <p class="section-title">アップロードキー</p>
         <p class="section-label">アップロードキー</p>
         <div class="upload-key-box">{{.Book.UploadKey}}</div>
         <div class="security-notice">&#x26A0; このキーは外部に公開しないでください。</div>


### PR DESCRIPTION
## 概要

日記帳の設定画面（`/books/{id}/settings`）に名前変更機能を追加する。
作成後でも日記帳の名前を変更できるようにする。

## 関連Issue

Fixes: #173

## 修正内容

- **マイグレーション**: `000008_add_book_name_length_check` を追加
  - SQLiteテーブル再作成方式で `books` テーブルに `CHECK(length(name) <= 50)` を追加
  - 外部キー制約を一時無効化して既存データを完全保持
- **ドメイン層**: `BookRepository` インターフェースに `UpdateBookName(id int, name string) error` を追加
- **インフラ層**: `SQLiteBookRepository` に `UpdateBookName` を実装（`UPDATE books SET name = ? WHERE id = ?`）
- **モック**: `MockBookRepository` に `UpdateBookName` を実装
- **ハンドラ**: `POST /books/{id}/settings` ルートと `handleBookSettingsPost` ハンドラを追加
  - 必須チェック（空文字不可）と文字数チェック（50文字以下）を実施
  - 作成者以外は HTTP 403 を返す
  - 更新成功時は `?success=1` 付きでリダイレクト
- **ハンドラ**: `handlePostBooks`（日記帳作成）にも同じ50文字制限を追加
- **ハンドラ**: `handleBookSettings`（GET）に `Success` フラグと `FormName` を追加
- **テンプレート**: `book_settings.html` を更新
  - 名前変更フォーム（`maxlength="50"`付き）を追加
  - 成功メッセージ・エラーメッセージ表示領域を追加
  - 既存のアップロードキー表示セクションを維持
- **テスト**: `migration_test.go` の `numMigrations` を 8 に更新（000007 追加分も含む）
- **テスト**: E2E テストを4件追加（成功・空文字エラー・51文字超エラー・非オーナー403）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)