### PR TITLE
#175 tblsによるDBスキーマドキュメント自動生成の環境を整備する

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/base:noble
 ENV CLAUDE_CONFIG_DIR=/home/vscode/.claude
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends tmux && \
+    apt-get install -y --no-install-recommends tmux sqlite3 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,3 +10,6 @@ if [ ! -f "$SCRIPT_DIR/.env" ] && [ -f "$SCRIPT_DIR/.env-template" ]; then
     cp "$SCRIPT_DIR/.env-template" "$SCRIPT_DIR/.env"
     echo ".env file created from .env-template"
 fi
+
+# install tbls
+go install github.com/k1LoW/tbls@latest

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ data/
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Generated DB schema docs
+docs/db/
+
+# Temp files
+tmp/

--- a/.tbls.yml
+++ b/.tbls.yml
@@ -1,0 +1,2 @@
+dsn: "sqlite3://tmp/schema.db"
+docPath: docs/db

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,11 @@ test-e2e:
 .PHONY: build
 build:
 	go build -v ./...
+
+.PHONY: doc-db
+doc-db:
+	mkdir -p tmp
+	for f in $$(ls migrations/*.up.sql | sort); do sqlite3 tmp/schema.db < $$f; done
+	tbls doc --force
+	rm -f tmp/schema.db
+	@rmdir --ignore-fail-on-non-empty tmp 2>/dev/null || true


### PR DESCRIPTION
## 概要

tbls を使ったDBスキーマドキュメント自動生成の環境を整備する。

## 変更内容

- `.tbls.yml` を追加（SQLiteのDSNと `docs/db/` 出力先を設定）
- `Makefile` に `doc-db` ターゲットを追加
  - 一時SQLiteデータベースを作成
  - マイグレーションを順番に適用して最新スキーマを構築
  - `tbls doc --force` でドキュメントを生成
  - 一時データベースファイルを削除
- `.gitignore` に `docs/db/` と `tmp/` を追加（生成物をgit管理外に）
- `.devcontainer/Dockerfile` に `sqlite3` を追加
- `.devcontainer/post-create.sh` に tbls のインストールを追加（`go install github.com/k1LoW/tbls@latest`）

## 使い方

```bash
make doc-db
```

実行後、`docs/db/` にテーブルごとのMarkdownファイルが生成される。

Closes #175