### PR TITLE
#178 go-depcheckを導入してレイヤー間の依存ルールをCIで自動チェックする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Format check
         run: make fmt-check
 
+      - name: Install depcheck
+        run: go install github.com/v-standard/go-depcheck/cmd/depcheck@latest
+
+      - name: Dependency check
+        run: make depcheck
+
       - name: Lint
         run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ fmt-check:
 lint:
 	go vet ./...
 
+.PHONY: depcheck
+depcheck:
+	go vet -vettool=$(shell which depcheck) ./...
+
 .PHONY: test
 test:
 	go test -v -race -coverprofile=coverage.out ./...

--- a/depcheck.yml
+++ b/depcheck.yml
@@ -1,0 +1,23 @@
+ignorePatterns:
+  - '_test\.go$'
+  - 'mock\.go$'
+  - 'mock_.*\.go$'
+
+rules:
+  # Domain層: 他のどのレイヤーにも依存しない
+  - from: '^plant-diary/internal/domain'
+    to:
+      - '^plant-diary/internal/usecase'
+      - '^plant-diary/internal/adapter'
+      - '^plant-diary/internal/infra'
+
+  # Usecase層: Adapter層・Infra層に依存しない
+  - from: '^plant-diary/internal/usecase'
+    to:
+      - '^plant-diary/internal/adapter'
+      - '^plant-diary/internal/infra'
+
+  # Adapter層: Infra層に依存しない
+  - from: '^plant-diary/internal/adapter'
+    to:
+      - '^plant-diary/internal/infra'


### PR DESCRIPTION
## 概要

go-depcheckを使ってクリーンアーキテクチャのレイヤー間依存ルールをCIで自動チェックする仕組みを導入します。

Closes #178

## 変更内容

- `depcheck.yml`を新規作成（Domain/Usecase/Adapter層の依存ルールを定義）
- `Makefile`に`depcheck`ターゲットを追加
- `.github/workflows/build.yml`にdepcheckのインストールと実行ステップを追加

## 依存ルール

| 元レイヤー | 禁止依存先 |
|-----------|-----------|
| Domain層 | Usecase層・Adapter層・Infra層 |
| Usecase層 | Adapter層・Infra層 |
| Adapter層 | Infra層 |

テストファイル(`_test.go`)およびモックファイル(`mock.go`, `mock_*.go`)は除外対象。