### PR TITLE
#181 create-issue スキルを追加する

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: create-issue
+description: ユーザーとの会話で仕様を整理し、GitHub Issueを作成する。実装は行わない。
+context: fork
+agent: general-purpose
+allowed-tools: Bash Read Grep Glob WebSearch WebFetch AskUserQuestion
+disable-model-invocation: false
+user-invocable: true
+argument-hint: "[topic]"
+---
+
+# Create Issue スキル
+
+## 役割
+
+ユーザーと会話しながら仕様を整理し、GitHub Issueを作成します。
+実装は行いません。Issue作成のみに専念します。
+
+## ワークフロー
+
+### 1. ヒアリング
+
+引数にトピックが指定されていれば、それを起点に会話を始める。
+指定がなければ、何について Issue を作成したいか確認する。
+
+`AskUserQuestion` を使って以下を確認：
+- 何を実現したいか（目的・ゴール）
+- 背景・動機（なぜ必要か）
+- 制約・考慮事項（あれば）
+
+### 2. 調査
+
+必要に応じてコードベースを調査し、実現可能性や影響範囲を把握する。
+
+```bash
+# 関連ファイルの検索
+# Glob, Grep, Read で調査
+```
+
+### 3. 仕様整理
+
+会話の内容を Issue の形にまとめる。以下の構成を基本とする：
+
+```markdown
+## 概要
+（何をするか、1〜2文で）
+
+## 背景
+（なぜ必要か）
+
+## やりたいこと
+（具体的な要件・受け入れ条件）
+
+## 実装方針（任意）
+（技術的なアプローチや注意点があれば）
+```
+
+### 4. 確認
+
+`AskUserQuestion` でユーザーにドラフト内容を提示し、承認を得る。
+修正依頼があれば内容を調整して再度確認する。
+
+### 5. Issue 作成
+
+承認を得たら `gh issue create` で Issue を作成する。
+
+```bash
+gh issue create \
+  --title "タイトル" \
+  --body "$(cat <<'EOF'
+## 概要
+...
+EOF
+)"
+```
+
+作成後、Issue の URL をユーザーに報告する。
+
+## 重要な制約
+
+### 禁止操作
+- ❌ ファイルの作成・編集（`Write`, `Edit`, `NotebookEdit`）
+- ❌ `git add`, `git commit`, `git push`
+- ❌ 実装作業全般
+
+### 許可操作
+- ✅ 読み取り: `Read`, `Grep`, `Glob`（調査用）
+- ✅ `Bash`: `gh issue create` および読み取り専用コマンド（`git log`, `git diff`, `git status` 等）
+- ✅ `WebSearch`, `WebFetch`（技術調査用）
+- ✅ `AskUserQuestion`（ユーザーへの確認）
+
+## 使用例
+
+```bash
+# トピックを指定して起動
+/create-issue APIドキュメント生成機能
+
+# トピックなしで起動（会話から始める）
+/create-issue
+```


### PR DESCRIPTION
## 概要

仕様相談から GitHub Issue を作成するワークフローをスキル化する。
実装に着手せず Issue 作成に専念させるためのユーザー起動スキル。

## 関連Issue

Fixes: #181

## 修正内容

- `.claude/skills/create-issue/SKILL.md` を新規追加
  - frontmatter: name, description, context, agent, allowed-tools 等を定義
  - ワークフロー: ヒアリング → 調査 → 仕様整理 → 確認 → Issue作成 の5ステップ
  - 禁止操作（ファイル編集・コミット・実装）と許可操作を明記

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)