### PR TITLE
watch-issue.shのログ表示を改善（待機中ドット表示・処理開始の強調表示）

### DIFF
--- a/.claude/scripts/watch-issue.sh
+++ b/.claude/scripts/watch-issue.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 INTERVAL_SECONDS=60
+waiting=false
 
 # Ctrl-C（SIGINT）で正常終了するためのトラップ
-trap 'echo "Stopping watch-issue.sh..."; exit 0' INT
+trap 'if [ "$waiting" = true ]; then echo ""; fi; echo "Stopping watch-issue.sh..."; exit 0' INT
 
 while true; do
   # assign-to-claudeラベル付き、かつin-progress-by-claudeラベルが付いていないissueを1件取得（古い順）
@@ -17,9 +18,22 @@ while true; do
 
   # 対象issueが存在しない場合
   if [ -z "$issue_number" ]; then
-    echo "No issues to process"
+    if [ "$waiting" = false ]; then
+      printf "Waiting for issues..."
+      waiting=true
+    else
+      printf "."
+    fi
   else
+    # Issue検出時: 待機中だった場合は改行
+    if [ "$waiting" = true ]; then
+      echo ""
+      waiting=false
+    fi
+
+    echo "----------------------------------------"
     echo "Processing issue #$issue_number"
+    echo "----------------------------------------"
 
     # in-progress-by-claudeラベルを付与
     gh issue edit "$issue_number" --add-label "in-progress-by-claude"
@@ -35,6 +49,5 @@ while true; do
   fi
 
   # 一定時間待機
-  echo "Waiting ${INTERVAL_SECONDS} seconds..."
   sleep "$INTERVAL_SECONDS"
 done


### PR DESCRIPTION
## 概要

`watch-issue.sh` の待機中ログと処理開始ログの表示を改善し、視認性を向上させる。

## 変更内容

### 待機中のログ表示をドット形式に変更

- 最初の待機時: `Waiting for issues...` を1行出力
- 2回目以降の待機: 改行なしでドット `.` を追記
- Issue発見時: 改行して次フェーズへ移行

### 処理開始ログを強調表示

- 区切り線（`---...---`）で処理開始ログを上下に囲む

**表示イメージ：**
```
Waiting for issues....
----------------------------------------
Processing issue #123
----------------------------------------
```

### その他

- SIGINT（Ctrl-C）で中断した場合も、待機中であれば改行を出力して端末表示を整える
- 毎ループの `Waiting N seconds...` ログを削除（ドット表示に統合）

## 関連Issue

Closes #184