### PR TITLE
#176 migration_test.go の numMigrations をマイグレーションファイル数から自動算出

### DIFF
--- a/internal/infra/sqlite/migration_test.go
+++ b/internal/infra/sqlite/migration_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+	"path/filepath"
 	"testing"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -76,7 +77,11 @@ func TestMigrations_AllDown(t *testing.T) {
 func TestMigrations_StepByStep(t *testing.T) {
 	_, m := setupMigrate(t)
 
-	const numMigrations = 8
+	files, err := filepath.Glob("../../../migrations/*.up.sql")
+	if err != nil {
+		t.Fatalf("failed to glob migration files: %v", err)
+	}
+	numMigrations := len(files)
 
 	// 1ステップずつUpを適用
 	for step := 1; step <= numMigrations; step++ {


### PR DESCRIPTION
## 概要

`TestMigrations_StepByStep` で手動管理していた定数 `numMigrations` を、`filepath.Glob` で `migrations/*.up.sql` ファイルをカウントする自動算出に置き換えた。

これにより、マイグレーションファイルを追加した際に `numMigrations` の更新を忘れて後半のマイグレーションがテストされないという問題を仕組みで防止できる。

## 関連Issue

Fixes: #176

## 修正内容

- `internal/infra/sqlite/migration_test.go`
  - `path/filepath` パッケージをインポートに追加
  - `const numMigrations = 8` を `filepath.Glob("../../../migrations/*.up.sql")` によるファイル数の自動算出に変更

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)