### PR TITLE
#180 make doc-api でSwagger UIベースのAPIドキュメントを生成できるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,8 @@ data/
 # Generated DB schema docs
 docs/db/
 
+# Generated API docs
+docs/api/
+
 # Temp files
 tmp/

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,19 @@ test-e2e:
 build:
 	go build -v ./...
 
+SWAGGER_UI_VERSION=5.19.0
+OPENAPI_YML_URL=https://raw.githubusercontent.com/canpok1/plant-diary/refs/heads/main/docs/openapi.yaml
+
+.PHONY: doc-api
+doc-api:
+	mkdir -p docs/api
+	curl -L https://github.com/swagger-api/swagger-ui/archive/refs/tags/v$(SWAGGER_UI_VERSION).zip -o docs/api/swagger-ui.zip
+	unzip docs/api/swagger-ui.zip -d docs/api
+	cp -R docs/api/swagger-ui-$(SWAGGER_UI_VERSION)/dist/* docs/api/
+	sed -i 's@url:.*@url: "$(OPENAPI_YML_URL)",@g' docs/api/swagger-initializer.js
+	rm -r docs/api/swagger-ui-$(SWAGGER_UI_VERSION)
+	rm docs/api/swagger-ui.zip
+
 .PHONY: doc-db
 doc-db:
 	mkdir -p tmp


### PR DESCRIPTION
## 概要

`make doc-api` を実行すると Swagger UI ベースの API ドキュメントが `docs/api/` 配下に生成されるようにする。

## 変更内容

- `Makefile`: `doc-api` ターゲットを追加
  - Swagger UI (v5.19.0) の GitHub リリース zip を `curl` + `unzip` で取得
  - `docs/api/` 配下に展開・配置
  - `swagger-initializer.js` の url を `docs/openapi.yaml` の raw URL に書き換え
- `.gitignore`: `docs/api/` を追加（生成物はコミットしない）

Closes #180