### PR TITLE
#183 CLAUDE.md のスキル一覧に create-issue を追加する

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,7 @@
 
 - `managing-team`: 複数のClaudeエージェントで協力開発
 - `quality-check`: コミットやPR作成後のレビュー
+- `create-issue`: 仕様相談からGitHub Issueを作成
 
 これらのスキルは `.claude/skills/` 配下で管理されており、改善提案がある場合はこのリポジトリにIssueを作成してください。
 


### PR DESCRIPTION
## 概要

CLAUDE.md の「このリポジトリで管理しているスキル」セクションに `create-issue` スキルの記載が漏れていたため追記しました。

## 変更内容

- `.claude/CLAUDE.md` に `create-issue` スキルを追加

## 関連Issue

Closes #183