### PR TITLE
#189 日記帳管理画面を日記帳作成画面に再構成する

### DIFF
--- a/internal/adapter/handler/book.go
+++ b/internal/adapter/handler/book.go
@@ -45,8 +45,8 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleGetBooks はログインユーザーの日記帳一覧ページを表示する
-func (s *Server) handleGetBooks(w http.ResponseWriter, r *http.Request) {
+// handleGetBooksNew は日記帳作成ページを表示する
+func (s *Server) handleGetBooksNew(w http.ResponseWriter, r *http.Request) {
 	user, err := s.getCurrentUser(r)
 	if err != nil {
 		log.Printf("ERROR: failed to get current user: %v", err)
@@ -58,15 +58,7 @@ func (s *Server) handleGetBooks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	books, err := s.bookRepo.GetBooksByCreatorID(user.ID)
-	if err != nil {
-		log.Printf("ERROR: failed to get books for user %d: %v", user.ID, err)
-		s.renderError(w, http.StatusInternalServerError)
-		return
-	}
-
 	data := map[string]interface{}{
-		"Books":    books,
 		"LoggedIn": true,
 		"Username": user.Username,
 	}

--- a/internal/adapter/handler/e2e_test.go
+++ b/internal/adapter/handler/e2e_test.go
@@ -298,8 +298,8 @@ func TestE2E_Login_InvalidCredentials(t *testing.T) {
 	}
 }
 
-// TestE2E_GetBooks_Unauthorized は未ログイン時にGET /booksが/loginへリダイレクトすることを検証する
-func TestE2E_GetBooks_Unauthorized(t *testing.T) {
+// TestE2E_GetBooksNew_Unauthorized は未ログイン時にGET /books/newが/loginへリダイレクトすることを検証する
+func TestE2E_GetBooksNew_Unauthorized(t *testing.T) {
 	ts := setupE2EServer(t)
 
 	client := &http.Client{
@@ -308,9 +308,9 @@ func TestE2E_GetBooks_Unauthorized(t *testing.T) {
 		},
 	}
 
-	resp, err := client.Get(ts.URL + "/books")
+	resp, err := client.Get(ts.URL + "/books/new")
 	if err != nil {
-		t.Fatalf("GET /books failed: %v", err)
+		t.Fatalf("GET /books/new failed: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -324,8 +324,8 @@ func TestE2E_GetBooks_Unauthorized(t *testing.T) {
 	}
 }
 
-// TestE2E_GetBooks_Authorized はログイン後にGET /booksが200を返すことを検証する
-func TestE2E_GetBooks_Authorized(t *testing.T) {
+// TestE2E_GetBooksNew_Authorized はログイン後にGET /books/newが200を返すことを検証する
+func TestE2E_GetBooksNew_Authorized(t *testing.T) {
 	ts := setupE2EServer(t)
 
 	// ユーザー作成
@@ -359,9 +359,9 @@ func TestE2E_GetBooks_Authorized(t *testing.T) {
 		t.Fatalf("login failed with status %d", loginResp.StatusCode)
 	}
 
-	// セッションCookieを使って /books にアクセス
+	// セッションCookieを使って /books/new にアクセス
 	cookies := loginResp.Cookies()
-	req, err := http.NewRequest("GET", ts.URL+"/books", nil)
+	req, err := http.NewRequest("GET", ts.URL+"/books/new", nil)
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestE2E_GetBooks_Authorized(t *testing.T) {
 
 	booksResp, err := client.Do(req)
 	if err != nil {
-		t.Fatalf("GET /books failed: %v", err)
+		t.Fatalf("GET /books/new failed: %v", err)
 	}
 	defer booksResp.Body.Close()
 

--- a/internal/adapter/handler/server.go
+++ b/internal/adapter/handler/server.go
@@ -76,7 +76,7 @@ func NewServer(repo domain.DiaryRepository, userRepo domain.UserRepository, book
 	s.mux.HandleFunc("GET /login", s.handleLoginGet)
 	s.mux.HandleFunc("POST /login", s.handleLoginPost)
 	s.mux.HandleFunc("POST /logout", s.handleLogout)
-	s.mux.HandleFunc("GET /books", s.requireLogin(s.handleGetBooks))
+	s.mux.HandleFunc("GET /books/new", s.requireLogin(s.handleGetBooksNew))
 	s.mux.HandleFunc("POST /books", s.requireLogin(s.handlePostBooks))
 	s.mux.HandleFunc("GET /books/{id}", s.handleGetBook)
 	s.mux.HandleFunc("GET /books/{id}/settings", s.requireLogin(s.handleBookSettings))

--- a/templates/book_detail.html
+++ b/templates/book_detail.html
@@ -236,7 +236,7 @@
         <h1><a href="/">植物観察日記</a></h1>
         <nav>
             {{if .LoggedIn}}
-            <a href="/books">日記帳管理</a>
+            <a href="/books/new">日記帳作成</a>
             <span class="user-info">{{.Username}}</span>
             <form method="POST" action="/logout" style="display:inline">
                 <button type="submit" class="logout-btn">ログアウト</button>

--- a/templates/book_settings.html
+++ b/templates/book_settings.html
@@ -220,7 +220,7 @@
     <header>
         <h1><a href="/">植物観察日記</a></h1>
         <nav>
-            <a href="/books">日記帳管理</a>
+            <a href="/books/new">日記帳作成</a>
             <span class="user-info">{{.Username}}</span>
             <form method="POST" action="/logout" style="display:inline">
                 <button type="submit" class="logout-btn">ログアウト</button>

--- a/templates/books.html
+++ b/templates/books.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>植物観察日記 - 日記帳一覧</title>
+    <title>植物観察日記 - 日記帳作成</title>
     <style>
         * {
             margin: 0;
@@ -94,47 +94,6 @@
             color: #333333;
         }
 
-        .books-table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-bottom: 32px;
-        }
-
-        .books-table th {
-            background-color: #f5f5f5;
-            border: 1px solid #e0e0e0;
-            padding: 10px 16px;
-            text-align: left;
-            font-size: 0.9rem;
-            color: #555555;
-        }
-
-        .books-table td {
-            border: 1px solid #e0e0e0;
-            padding: 10px 16px;
-            font-size: 0.95rem;
-        }
-
-        .books-table tr:hover td {
-            background-color: #f9f9f9;
-        }
-
-        .books-table a {
-            color: #4a7c59;
-            text-decoration: none;
-            font-weight: bold;
-        }
-
-        .books-table a:hover {
-            text-decoration: underline;
-        }
-
-        .empty-message {
-            color: #888888;
-            padding: 24px 0;
-            font-size: 0.95rem;
-        }
-
         .create-form {
             background-color: #f9f9f9;
             border: 1px solid #e0e0e0;
@@ -196,10 +155,6 @@
                 margin: 16px auto;
                 padding: 0 12px;
             }
-
-            .books-table {
-                font-size: 0.85rem;
-            }
         }
     </style>
 </head>
@@ -207,7 +162,7 @@
     <header>
         <h1><a href="/">植物観察日記</a></h1>
         <nav>
-            <a href="/books">日記帳</a>
+            <a href="/books/new">日記帳作成</a>
             <span class="user-info">{{.Username}}</span>
             <form method="POST" action="/logout" style="display:inline">
                 <button type="submit" class="logout-btn">ログアウト</button>
@@ -215,31 +170,7 @@
         </nav>
     </header>
     <main>
-        <h2>日記帳一覧</h2>
-        {{if .Books}}
-        <table class="books-table">
-            <thead>
-                <tr>
-                    <th>名前</th>
-                    <th>作成日</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {{range .Books}}
-                <tr>
-                    <td>{{.Name}}</td>
-                    <td>{{(.CreatedAt | toJST).Format "2006年1月2日 15:04"}}</td>
-                    <td><a href="/books/{{.ID}}">詳細</a></td>
-                </tr>
-                {{end}}
-            </tbody>
-        </table>
-        {{else}}
-        <p class="empty-message">まだ日記帳がありません。</p>
-        {{end}}
-
-        <h2>新しい日記帳を作成</h2>
+        <h2>日記帳作成</h2>
         <form class="create-form" method="POST" action="/books">
             <label for="name">日記帳の名前</label>
             <input type="text" id="name" name="name" placeholder="例: わたしの植物日記" required>

--- a/templates/index.html
+++ b/templates/index.html
@@ -151,7 +151,7 @@
         <h1>植物観察日記</h1>
         <nav>
             {{if .LoggedIn}}
-            <a href="/books">日記帳管理</a>
+            <a href="/books/new">日記帳作成</a>
             <span class="user-info">{{.Username}}</span>
             <form method="POST" action="/logout" style="display:inline">
                 <button type="submit" class="logout-btn">ログアウト</button>


### PR DESCRIPTION
## 概要

日記帳管理画面（`/books`）を日記帳作成画面（`/books/new`）に再構成する。

## 変更内容

- `GET /books` → `GET /books/new` にルーティング変更
- `handleGetBooks` → `handleGetBooksNew` にリネームし、一覧取得ロジック（`GetBooksByCreatorID`）を削除
- `books.html` から日記帳一覧テーブルを削除し作成フォームのみに変更、タイトルを「日記帳作成」に更新
- 全テンプレートのナビゲーションリンクを `/books/new`「日記帳作成」に更新
  - `index.html`: `日記帳管理` → `日記帳作成`
  - `book_detail.html`: `日記帳管理` → `日記帳作成`
  - `book_settings.html`: `日記帳管理` → `日記帳作成`
  - `books.html`: `日記帳` → `日記帳作成`
- E2Eテストのエンドポイントを `/books/new` に更新

Closes #189