### PR TITLE
#191 watch-issue.sh: solve-issue完了後にin-progress-by-claudeラベルを外す

### DIFF
--- a/.claude/scripts/watch-issue.sh
+++ b/.claude/scripts/watch-issue.sh
@@ -38,14 +38,11 @@ while true; do
     # in-progress-by-claudeラベルを付与
     gh issue edit "$issue_number" --add-label "in-progress-by-claude"
 
-    # エラー時にラベルを削除するトラップを設定
-    trap "gh issue edit \"$issue_number\" --remove-label \"in-progress-by-claude\" || true" ERR
+    # solve-issue.shを実行（エラーでも継続）
+    "$(dirname "$0")/solve-issue.sh" -p "$issue_number" || true
 
-    # solve-issue.shを実行
-    "$(dirname "$0")/solve-issue.sh" -p "$issue_number"
-
-    # ERRトラップを解除
-    trap - ERR
+    # 処理完了後、ラベルを外す（成否を問わず）
+    gh issue edit "$issue_number" --remove-label "in-progress-by-claude" || true
   fi
 
   # 一定時間待機


### PR DESCRIPTION
## 概要

`watch-issue.sh` で `solve-issue.sh` の処理が完了した後、`in-progress-by-claude` ラベルをシェルスクリプト側で外すようにする。

## 変更内容

- `solve-issue.sh` の呼び出しに `|| true` を追加し、エラーが発生しても処理を継続するように変更
- `solve-issue.sh` 完了後（成否を問わず）に `in-progress-by-claude` ラベルを削除する処理を追加
- `ERR` トラップによるラベル削除と解除を削除（不要になったため）

## 動作

| ケース | ラベル削除 |
|--------|-----------|
| solve-issue.sh が正常終了 | ラベルを削除 |
| solve-issue.sh が異常終了 | ラベルを削除（`\|\| true` により継続） |
| ERRトラップが引っかからないケース | ラベルを削除（後処理が必ず実行される） |

Closes #191