### PR TITLE
#195 ホスト上で devcontainer CLI 経由で watch-issue.sh を実行するスクリプトを追加

### DIFF
--- a/scripts/watch-on-host.sh
+++ b/scripts/watch-on-host.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# ホスト（macOS）から devcontainer CLI 経由で watch-issue.sh を実行するスクリプト
+#
+# === 使い方 ===
+#   ./scripts/watch-on-host.sh
+#
+# === 前提条件 ===
+# - devcontainer CLI がインストールされていること
+#   インストール方法: npm install -g @devcontainers/cli
+# - Docker が起動していること
+#
+# === 動作フロー ===
+# 1. devcontainer up でコンテナを起動（既存コンテナがある場合は再利用）
+# 2. devcontainer exec でコンテナ内の watch-issue.sh を実行
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "=== コンテナを起動中... ==="
+devcontainer up --workspace-folder "${WORKSPACE_DIR}"
+
+echo ""
+echo "=== watch-issue.sh を実行中... ==="
+devcontainer exec --workspace-folder "${WORKSPACE_DIR}" \
+  bash -c ".claude/scripts/watch-issue.sh"


### PR DESCRIPTION
## 概要

ホスト（macOS）から devcontainer CLI 経由で `watch-issue.sh` を実行するスクリプト `scripts/watch-on-host.sh` を追加する。

## 変更内容

- `scripts/watch-on-host.sh` を新規作成
  - `devcontainer up` でコンテナを起動（既存コンテナがある場合は再利用）
  - `devcontainer exec` でコンテナ内の `watch-issue.sh` を実行
  - 使い方・前提条件・動作フローのコメントを記載

## 動作確認

ホスト（macOS）から以下を実行すると devcontainer が起動し、`watch-issue.sh` がコンテナ内で動作する。

```bash
./scripts/watch-on-host.sh
```

Closes #195