### PR TITLE
#197 watch-issue.sh: Claudeの処理開始・完了メッセージを表示する

### DIFF
--- a/.claude/scripts/watch-issue.sh
+++ b/.claude/scripts/watch-issue.sh
@@ -38,11 +38,17 @@ while true; do
     # in-progress-by-claudeラベルを付与
     gh issue edit "$issue_number" --add-label "in-progress-by-claude"
 
+    # 処理開始メッセージ
+    echo "Starting Claude for issue #$issue_number..."
+
     # solve-issue.shを実行（エラーでも継続）
     "$(dirname "$0")/solve-issue.sh" -p "$issue_number" || true
 
     # 処理完了後、ラベルを外す（成否を問わず）
     gh issue edit "$issue_number" --remove-label "in-progress-by-claude" || true
+
+    # 処理完了メッセージ
+    echo "Completed processing issue #$issue_number."
   fi
 
   # 一定時間待機


### PR DESCRIPTION
## 概要

`watch-issue.sh` にClaudeの処理開始・完了メッセージを追加する。

## 変更内容

- `solve-issue.sh` 呼び出し前に処理開始メッセージを表示: `Starting Claude for issue #$issue_number...`
- `solve-issue.sh` 完了後（ラベル削除後）に処理完了メッセージを表示: `Completed processing issue #$issue_number.`

## 背景

処理中の状態が不明だったため、メッセージを追加してスクリプトの状態を分かりやすくした。

Closes #197