### PR TITLE
#198 create-issueスキルのdescriptionに手動実行時のみ使用する旨を追記

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-issue
-description: ユーザーとの会話で仕様を整理し、GitHub Issueを作成する。実装は行わない。
+description: ユーザーが `/create-issue` で手動実行した場合のみ使用。ユーザーとの会話で仕様を整理し、GitHub Issueを作成する。実装は行わない。
 context: fork
 agent: general-purpose
 allowed-tools: Bash Read Grep Glob WebSearch WebFetch AskUserQuestion


### PR DESCRIPTION
## 概要

`create-issue` スキルの `description` フィールドに、`/create-issue` コマンドで手動実行した場合のみ使用する旨を追記した。

## 変更内容

- `.claude/skills/create-issue/SKILL.md` の `description` を更新

Closes #198