### PR TITLE
#205 スキルのallowed-toolsをカンマ区切りに統一しmanaging-teamに不足ツールを追記

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -3,7 +3,7 @@ name: create-issue
 description: ユーザーが `/create-issue` で手動実行した場合のみ使用。ユーザーとの会話で仕様を整理し、GitHub Issueを作成する。実装は行わない。
 context: fork
 agent: general-purpose
-allowed-tools: Bash Read Grep Glob WebSearch WebFetch AskUserQuestion
+allowed-tools: Bash, Read, Grep, Glob, WebSearch, WebFetch, AskUserQuestion
 disable-model-invocation: false
 user-invocable: true
 argument-hint: "[topic]"

--- a/.claude/skills/managing-team/SKILL.md
+++ b/.claude/skills/managing-team/SKILL.md
@@ -3,7 +3,7 @@ name: managing-team
 description: 複数のClaudeエージェントで協力開発する際に使用。リーダーが実装から離れて進捗管理・チーム調整に専念し、チーム全体の生産性を向上させる。
 context: fork
 agent: general-purpose
-allowed-tools: TeamCreate TeamDelete TaskCreate TaskList TaskUpdate TaskGet SendMessage Bash Read Grep Glob WebSearch Skill
+allowed-tools: TeamCreate, TeamDelete, TaskCreate, TaskList, TaskUpdate, TaskGet, TaskOutput, TaskStop, SendMessage, Bash, Read, Grep, Glob, WebSearch, Skill
 disable-model-invocation: false
 user-invocable: true
 argument-hint: "[team-name] [task-description]"

--- a/.claude/skills/quality-check/SKILL.md
+++ b/.claude/skills/quality-check/SKILL.md
@@ -3,7 +3,7 @@ name: quality-check
 description: コミットやPR作成後に使用。linterでチェックできない設計・実装パターン（インターフェース設計、エラーハンドリング、テスト戦略等）をレビューしてフィードバックを提供する。
 context: fork
 agent: general-purpose
-allowed-tools: Bash Read Grep Glob SendMessage
+allowed-tools: Bash, Read, Grep, Glob, SendMessage
 disable-model-invocation: false
 user-invocable: true
 argument-hint: "[target-commit-or-pr]"

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -3,7 +3,7 @@ name: tdd
 description: 実装タスクをTDDで進める場合に使用。テストリスト作成 → Red → Green → Refactor のサイクルをベビーステップで繰り返す。
 context: fork
 agent: general-purpose
-allowed-tools: Bash Read Grep Glob Write Edit
+allowed-tools: Bash, Read, Grep, Glob, Write, Edit
 disable-model-invocation: false
 user-invocable: true
 argument-hint: "[task-description]"


### PR DESCRIPTION
## Summary

- `quality-check`, `managing-team`, `create-issue`, `tdd` スキルの `allowed-tools` をスペース区切りからカンマ区切りに統一（公式スキルの記載形式に合わせる）
- `managing-team` に `TaskOutput`, `TaskStop` を追加（タスク監視・強制停止に必要なツールが未記載だったため）
- `solve-issue` は `disable-model-invocation: true` のインライン展開スキルのため、`allowed-tools` の追加は不要と判断

## Test plan

- [ ] 各スキルファイルの `allowed-tools` がカンマ区切りになっていることを確認
- [ ] `managing-team/SKILL.md` に `TaskOutput`, `TaskStop` が含まれていることを確認

Closes #205

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)