### PR TITLE
fix: fix-pr/wait-coderabbit/monologue スクリプトの堅牢性改善 (#208)

### DIFF
--- a/.claude/skills/fix-pr/scripts/fix-pr.sh
+++ b/.claude/skills/fix-pr/scripts/fix-pr.sh
@@ -25,6 +25,10 @@ get_repo() {
 }
 
 REPO=$(get_repo)
+if [[ -z "$REPO" ]]; then
+    echo "リポジトリ情報の取得に失敗しました。" >&2
+    exit 3
+fi
 
 # ========================================
 # Step 1: ブランチ最新化チェック
@@ -45,7 +49,10 @@ if [[ "$MERGE_BASE" != "$REMOTE_MAIN" ]]; then
         exit 1
     fi
     echo "mainをマージしました。プッシュします..."
-    git push 2>/dev/null || true
+    if ! git push 2>/dev/null; then
+        echo "プッシュに失敗しました。" >&2
+        exit 3
+    fi
 else
     echo "ブランチは最新です。"
 fi
@@ -95,8 +102,9 @@ if [[ "$MERGE_EXIT" -eq 0 ]]; then
 fi
 
 # マージ失敗の原因を判定
-if echo "$MERGE_OUTPUT" | grep -qi "unresolved review\|review.*required\|required.*approv.*review\|review.*not.*resolved\|CHANGES_REQUESTED"; then
-    echo "未解決レビューが原因でマージできません。" >&2
+REVIEW_DECISION=$(gh pr view --repo "$REPO" "$PR_NUMBER" --json reviewDecision --jq '.reviewDecision // ""' 2>/dev/null || echo "")
+if [[ "$REVIEW_DECISION" == "CHANGES_REQUESTED" || "$REVIEW_DECISION" == "REVIEW_REQUIRED" ]]; then
+    echo "未解決レビューが原因でマージできません。（reviewDecision: $REVIEW_DECISION）" >&2
     echo "$MERGE_OUTPUT" >&2
     exit 2
 fi

--- a/.claude/skills/fix-pr/scripts/wait-coderabbit.sh
+++ b/.claude/skills/fix-pr/scripts/wait-coderabbit.sh
@@ -31,6 +31,10 @@ get_repo() {
 }
 
 REPO=$(get_repo)
+if [[ -z "$REPO" ]]; then
+    echo "リポジトリ情報の取得に失敗しました。" >&2
+    exit 1
+fi
 
 # CodeRabbitのコメント数を取得
 get_coderabbit_comment_count() {
@@ -61,16 +65,18 @@ check_changes_requested() {
     return 1  # CHANGES_REQUESTEDなし
 }
 
-# CodeRabbitのコメントからrate limit情報をチェック
+# CodeRabbitのコメントからrate limit情報をチェック（最新コメント/レビューのみ対象、1回のAPI呼び出しで取得）
 check_rate_limit() {
-    local comments
-    comments=$(gh pr view --repo "$REPO" "$PR_NUMBER" --json comments --jq '.comments[] | select(.author.login=="coderabbitai") | .body')
-    if echo "$comments" | grep -qi "rate limit"; then
+    local pr_data
+    pr_data=$(gh pr view --repo "$REPO" "$PR_NUMBER" --json comments,reviews)
+    local latest_comment
+    latest_comment=$(echo "$pr_data" | jq -r '[.comments[] | select(.author.login=="coderabbitai")] | last | .body // ""')
+    if echo "$latest_comment" | grep -qi "rate limit"; then
         return 0  # rate limitあり
     fi
-    local reviews
-    reviews=$(gh pr view --repo "$REPO" "$PR_NUMBER" --json reviews --jq '.reviews[] | select(.author.login=="coderabbitai") | .body')
-    if echo "$reviews" | grep -qi "rate limit"; then
+    local latest_review
+    latest_review=$(echo "$pr_data" | jq -r '[.reviews[] | select(.author.login=="coderabbitai")] | last | .body // ""')
+    if echo "$latest_review" | grep -qi "rate limit"; then
         return 0  # rate limitあり
     fi
     return 1  # rate limitなし

--- a/.claude/skills/monologue/scripts/monologue.sh
+++ b/.claude/skills/monologue/scripts/monologue.sh
@@ -18,7 +18,7 @@ if ! [[ "$PROBABILITY" =~ ^[0-9]+$ ]] || [ "$PROBABILITY" -lt 1 ] || [ "$PROBABI
   exit 1
 fi
 
-if ! [[ "$SPEAKER" =~ ^[0-9]+$ ]]; then
+if ! [[ "$SPEAKER" =~ ^[0-9]+$ ]] || [ "$SPEAKER" -lt 1 ]; then
   echo "[ERROR] スピーカーIDは正の整数で指定してください: '$SPEAKER'"
   exit 1
 fi


### PR DESCRIPTION
## 概要

PR #207 の CodeRabbit レビューで指摘されたスクリプトの堅牢性問題を修正します。

## 変更内容

### fix-pr.sh

- **git push 失敗時に処理継続してしまう問題を修正**
  - `git push 2>/dev/null || true` → 失敗時に `exit 3` するよう修正
- **エラーメッセージ文字列でのマージ失敗判定を修正**
  - `gh pr merge` のエラー文言 grep 判定 → `gh pr view --json reviewDecision` で `CHANGES_REQUESTED`/`REVIEW_REQUIRED` を判定するよう修正
- **REPO 取得失敗時の空チェックを追加**
  - `wait-coderabbit.sh` と同様に空チェックし `exit 3` するよう修正

### wait-coderabbit.sh

- **REPO 取得失敗時のエラーなしを修正**
  - `REPO=$(get_repo)` 後に空チェックを追加して `exit 1` するよう修正
- **rate limit 判定で過去コメントを全件走査している問題を修正**
  - 全コメント走査 → 最新コメント/レビューのみを対象にするよう修正
  - あわせて2回の API 呼び出しを `--json comments,reviews` で1回に統合

### monologue.sh

- **SPEAKER バリデーションが 0 を許容している問題を修正**
  - エラーメッセージは「正の整数」と言いつつ 0 を許容 → `-lt 1` を追加して揃える

Closes #208

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 自動マージ処理の信頼性を向上させました。無効な入力値の検出精度を高め、エラーハンドリングを強化しました。

* **改善**
  * API呼び出しを最適化し、パフォーマンスを向上させました。
  * 入力値の検証をより厳密にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->