### PR TITLE
feat: assign-issues.sh のフィルタに ready ラベル条件を追加

### DIFF
--- a/.claude/scripts/assign-issues.sh
+++ b/.claude/scripts/assign-issues.sh
@@ -27,14 +27,14 @@ source "$SCRIPT_DIR/lib/detect-repo.sh"
 # 現在のGitHubユーザーを取得
 source "$SCRIPT_DIR/lib/current-user.sh"
 
-# assign-to-claudeラベルが付いていないopen Issueを取得（古い順、ASSIGN_COUNT件）
+# assign-to-claudeラベルが付いておらずreadyラベルが付いているopen Issueを取得（古い順、ASSIGN_COUNT件）
 issue_numbers=$(gh issue list \
   --repo "$REPO" \
   --author "$CURRENT_USER" \
   --state open \
   --search "sort:created-asc" \
   --json number,labels \
-  --jq '.[] | select(.labels | map(.name) | contains(["assign-to-claude"]) | not) | .number' \
+  --jq '.[] | (.labels | map(.name)) as $names | select(($names | contains(["assign-to-claude"]) | not) and ($names | contains(["ready"]))) | .number' \
   | head -n "$ASSIGN_COUNT")
 
 if [ -z "$issue_numbers" ]; then


### PR DESCRIPTION
## 概要

- `assign-issues.sh` のjqフィルタに `ready` ラベル条件を追加
- `assign-to-claude` ラベルが付いておらず、かつ `ready` ラベルが付いているIssueのみを対象とする

## 変更内容

`.claude/scripts/assign-issues.sh` の `--jq` フィルタを修正:

```diff
- --jq '.[] | select(.labels | map(.name) | contains(["assign-to-claude"]) | not) | .number'
+ --jq '.[] | (.labels | map(.name)) as $names | select(($names | contains(["assign-to-claude"]) | not) and ($names | contains(["ready"]))) | .number'
```

- `ready` ラベル条件を AND で追加
- `map(.name)` の重複評価を排除（jq変数 `$names` に一度だけ抽出）

## 確認事項

- [x] `assign-to-claude` が付いておらず `ready` が付いているIssueのみがラベル付与対象となること
- [x] `ready` ラベルがないIssueはスキップされること

Closes #224

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 問題の自動割り当てのフィルター処理を改善しました。オープンな問題の選択基準を変更し、`ready`ラベルを含む問題に対してより正確に対応するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->