### PR TITLE
refactor: fix-pr.sh / wait-coderabbit.sh の get_repo() を detect-repo.sh に統合

### DIFF
--- a/.claude/scripts/lib/detect-repo.sh
+++ b/.claude/scripts/lib/detect-repo.sh
@@ -4,5 +4,8 @@
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 if [ -z "$REPO" ]; then
   echo "Error: リポジトリ情報を取得できませんでした" >&2
-  exit 1
+  # source経由（シェル関数外）でも安全に失敗するため、
+  # スクリプトとして直接実行された場合はexit、sourceされた場合はreturnを使う
+  # shellcheck disable=SC2317
+  return 1 2>/dev/null || exit 1
 fi

--- a/.claude/skills/fix-pr/scripts/fix-pr.sh
+++ b/.claude/skills/fix-pr/scripts/fix-pr.sh
@@ -21,7 +21,10 @@ PR_NUMBER="$1"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/lib/detect-repo.sh
-source "$SCRIPT_DIR/../../../scripts/lib/detect-repo.sh"
+if ! source "$SCRIPT_DIR/../../../scripts/lib/detect-repo.sh"; then
+    echo "リポジトリ情報の取得に失敗しました。" >&2
+    exit 3
+fi
 
 # ========================================
 # Step 1: ブランチ最新化チェック

--- a/.claude/skills/fix-pr/scripts/wait-coderabbit.sh
+++ b/.claude/skills/fix-pr/scripts/wait-coderabbit.sh
@@ -27,7 +27,10 @@ RATE_LIMIT_WAIT="${RATE_LIMIT_WAIT:-600}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/lib/detect-repo.sh
-source "$SCRIPT_DIR/../../../scripts/lib/detect-repo.sh"
+if ! source "$SCRIPT_DIR/../../../scripts/lib/detect-repo.sh"; then
+    echo "リポジトリ情報の取得に失敗しました。" >&2
+    exit 1
+fi
 
 # CodeRabbitのコメント数を取得
 get_coderabbit_comment_count() {


### PR DESCRIPTION
## 概要

`fix-pr.sh` と `wait-coderabbit.sh` に重複実装されていた `get_repo()` 関数を削除し、共通ライブラリ `detect-repo.sh` を source するよう変更しました。

## 変更内容

- `.claude/skills/fix-pr/scripts/fix-pr.sh`: `get_repo()` 関数を削除し `detect-repo.sh` を source
- `.claude/skills/fix-pr/scripts/wait-coderabbit.sh`: 同上

## 動作確認

- `detect-repo.sh` は `REPO` 変数を自動セットし、取得失敗時は `exit 1` で終了するため、従来と同等のエラーハンドリングが維持されます

Closes #215

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 複数のスクリプトで共通のリポジトリ検出ロジックを共有ライブラリに統合し、保守性と再利用性を向上しました。
* **Bug Fixes**
  * リポジトリ未検出時の終了処理の挙動を改善し、実行コンテキストに応じた安全なエラーハンドリングを導入しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->