### PR TITLE
feat: solve-issue完了後のmonologue通知とCLAUDE.mdへの思考プロセス通知指示を追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,3 +14,7 @@
     🤖 Generated with [Claude Code](https://claude.ai/claude-code)
     ```
   - 作成内容に不備がないか作成後に確認すること（例: Issueのレイアウトが崩れている、フッターが付与されていないなど）
+
+## monologueによる思考プロセスの通知
+
+作業中の思考プロセスや状況をユーザーが把握できるよう、適宜 `/monologue` スキルで独り言を呟くこと。

--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -62,6 +62,7 @@ GitHub Issue $ARGUMENTS を対応します。
 | 6. PR作成 | 追記 | PR番号とURL |
 | 7. fix-pr | 追記 | CI待機・レビュー対応・マージの結果 |
 | 8. 振り返り | 追記 | 作成したIssue番号（あれば） |
+| 9. 全作業完了通知 | なし | monologueのみ実行 |
 
 0. Issue の状態を確認する
   - `gh issue view $ARGUMENTS --json state --jq .state` で対象IssueのOPEN/CLOSED状態を確認する
@@ -95,3 +96,4 @@ GitHub Issue $ARGUMENTS を対応します。
 7. `/monologue` を実行してから、`/fix-pr` スキルでCI待機・レビュー対応・マージを行う
   - 引数にPR番号を渡す
 8. `/monologue` を実行してから、`/retro` スキルで振り返りを行う
+9. `/monologue` を実行して、全作業完了を通知する


### PR DESCRIPTION
## 概要

- `solve-issue/SKILL.md` に手順9（全作業完了後のmonologue通知）を追加
- `CLAUDE.md` に作業中の思考プロセスをmonologueで通知する指示セクションを追加

## 変更内容

- `.claude/skills/solve-issue/SKILL.md`: ステップ8（振り返り）の後にステップ9を追加し、全作業完了をmonologueで通知する手順を明記
- `.claude/CLAUDE.md`: `## monologueによる思考プロセスの通知` セクションを追加し、適宜monologueスキルを使うよう指示

## 関連Issue

Closes #230

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 作業プロセス中の進捗状況を通知する機能についてのガイダンスを追加しました
  * 作業完了時に完了通知を送信する新しいステップを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->