### PR TITLE
feat: solve-issueのPR作成時にCloses #Issue番号を含めるよう指示を追加

### DIFF
--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -94,6 +94,7 @@ GitHub Issue $ARGUMENTS を対応します。
   - 上記いずれにも該当しない場合（既存PRが存在しない場合）: ステップ6に進む
 6. `/monologue` を実行してから、`commit-commands:commit-push-pr` スキルでPRを作成する
   - PR本文に必ず `Closes #$ARGUMENTS` を含めること（マージ時にIssueが自動クローズされる）
+  - `commit-commands:commit-push-pr` スキルへPR本文を渡す際は `--body "Closes #$ARGUMENTS\n\n{説明}"` のように明示すること
 7. `/monologue` を実行してから、`/fix-pr` スキルでCI待機・レビュー対応・マージを行う
   - 引数にPR番号を渡す
 8. `/monologue` を実行してから、`/retro` スキルで振り返りを行う


### PR DESCRIPTION
## 概要

- `solve-issue` スキルのステップ6（PR作成）において、PR本文に `Closes #Issue番号` を含めるよう明示的に指示を追加

## 背景

Issue #218 がマージされた際に Issue #210 が自動クローズされなかった問題が発生した。PR本文に `Closes #番号` の記述がなかったことが原因。

## 変更内容

- `.claude/skills/solve-issue/SKILL.md` のステップ6に以下のサブ指示を追加:
  - `PR本文に必ず Closes #$ARGUMENTS を含めること（マージ時にIssueが自動クローズされる）`

## 期待する動作

- solve-issueスキルでPRを作成する際、PR本文に自動的に `Closes #Issue番号` が含まれるようになる
- PRがマージされると対応するIssueが自動クローズされる

Closes #220

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * PR作成手順を更新しました。Step 6 のコマンド指定を変更し、PR本文に必ず "Closes #$ARGUMENTS" を含めるように要求します。これにより、マージ時に関連するIssueが自動でクローズされます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->