### PR TITLE
fix(#243): worktree環境でのgit pushをorigin HEADに修正

### DIFF
--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -154,7 +154,7 @@ KNOWN_TOTAL=$(gh pr view --repo <REPO> <PR番号> --json comments,reviews \
 ```bash
 git add <修正したファイルパス...>
 git commit -m "fix: CodeRabbitの指摘を修正"
-git push
+git push origin HEAD
 ```
 
 #### 4. 返信・再レビュー依頼

--- a/.claude/skills/fix-pr/scripts/fix-pr.sh
+++ b/.claude/skills/fix-pr/scripts/fix-pr.sh
@@ -40,7 +40,7 @@ if [[ "$MERGE_BASE" != "$REMOTE_MAIN" ]]; then
         exit 1
     fi
     echo "mainをマージしました。プッシュします..."
-    if ! git push 2>/dev/null; then
+    if ! git push origin HEAD; then
         echo "プッシュに失敗しました。" >&2
         exit 3
     fi


### PR DESCRIPTION
Closes #243

## 変更内容

`fix-pr.sh` でmainブランチをマージした後の `git push` が、worktree環境でアップストリームが設定されていない場合に失敗する問題を修正しました。

### 修正箇所

- `.claude/skills/fix-pr/scripts/fix-pr.sh`: `git push 2>/dev/null` → `git push origin HEAD`
  - リモート・ブランチを明示的に指定することでworktree環境でも正常動作
  - `2>/dev/null` を削除し、エラー内容が表示されるように改善
- `.claude/skills/fix-pr/SKILL.md`: レビュー修正後のプッシュ例も `git push` → `git push origin HEAD` に統一

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* Git プッシュ操作の信頼性が向上しました。プッシュ先のリモートとブランチを明示的に指定するように変更し、環境設定への依存性を削減しました。プッシュ失敗時のエラー情報がより明確に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->