### PR TITLE
feat(#255): solve-issue.sh単体呼び出し時のロックとラベル管理を実装

### DIFF
--- a/.claude/scripts/solve-issue.sh
+++ b/.claude/scripts/solve-issue.sh
@@ -23,7 +23,30 @@ if ! [[ "${ISSUE_NUMBER}" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+SCRIPT_DIR=$(dirname "$0")
+WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ロックファイル用ディレクトリの準備
+LOCK_DIR="$WORKSPACE_DIR/.tmp/locks"
+mkdir -p "$LOCK_DIR"
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+# ロックを取得（取得できない場合は別プロセスが処理中）
+lock_file="$LOCK_DIR/issue-${ISSUE_NUMBER}.lock"
+exec 9>"$lock_file"
+if ! flock -n 9; then
+  echo "Error: Issue #${ISSUE_NUMBER} is already being processed by another process." >&2
+  exit 1
+fi
+
 echo "Issue #${ISSUE_NUMBER} の処理を開始します"
+
+# 処理完了後（成否問わず）にラベルを除去
+trap 'gh issue edit --repo "$REPO" "$ISSUE_NUMBER" --remove-label "in-progress-by-claude" || true' EXIT
+
+# in-progress-by-claudeラベルを付与
+gh issue edit --repo "$REPO" "$ISSUE_NUMBER" --add-label "in-progress-by-claude"
 
 # mainブランチに切り替えて最新化
 git checkout main

--- a/.claude/scripts/watch-queued-issues.sh
+++ b/.claude/scripts/watch-queued-issues.sh
@@ -5,11 +5,6 @@ INTERVAL_SECONDS=60
 waiting=false
 
 SCRIPT_DIR=$(dirname "$0")
-WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-
-# ロックファイル用ディレクトリの準備
-LOCK_DIR="$WORKSPACE_DIR/.tmp/locks"
-mkdir -p "$LOCK_DIR"
 
 # Ctrl-C（SIGINT）で正常終了するためのトラップ
 trap 'if [ "$waiting" = true ]; then echo ""; fi; echo "Stopping watch-queued-issues.sh..."; exit 0' INT
@@ -37,41 +32,24 @@ while true; do
       printf "."
     fi
   else
-    # Issue番号単位のロックを取得し、保持した状態で処理を実行
-    lock_file="$LOCK_DIR/issue-${issue_number}.lock"
-    (
-      flock -n 9 || { echo "Issue #$issue_number is locked by another process. Skipping."; exit 1; }
-
-      # Issue検出時: 待機中だった場合は改行
-      if [ "$waiting" = true ]; then
-        echo ""
-      fi
-
-      echo "----------------------------------------"
-      echo "Processing issue #$issue_number"
-      echo "----------------------------------------"
-
-      # in-progress-by-claudeラベルを付与
-      gh issue edit --repo "$REPO" "$issue_number" --add-label "in-progress-by-claude"
-
-      # 処理開始メッセージ
-      echo "Starting Claude for issue #$issue_number..."
-
-      # solve-issue.shを実行（エラーでも継続）
-      "$SCRIPT_DIR/solve-issue.sh" -p "$issue_number" || true
-
-      # 処理完了後、ラベルを外す（成否を問わず）
-      gh issue edit --repo "$REPO" "$issue_number" --remove-label "in-progress-by-claude" || true
-
-      # 処理完了メッセージ
-      echo "Completed processing issue #$issue_number."
-    ) 9>"$lock_file"
-    lock_result=$?
-
-    # ロック取得成功時のみ待機状態をリセット
-    if [ "$lock_result" -eq 0 ]; then
-      waiting=false
+    # Issue検出時: 待機中だった場合は改行
+    if [ "$waiting" = true ]; then
+      echo ""
     fi
+    waiting=false
+
+    echo "----------------------------------------"
+    echo "Processing issue #$issue_number"
+    echo "----------------------------------------"
+
+    # 処理開始メッセージ
+    echo "Starting Claude for issue #$issue_number..."
+
+    # solve-issue.shを実行（ロック取得・ラベル管理はsolve-issue.sh内で行う）
+    "$SCRIPT_DIR/solve-issue.sh" -p "$issue_number" || true
+
+    # 処理完了メッセージ
+    echo "Completed processing issue #$issue_number."
   fi
 
   # 一定時間待機


### PR DESCRIPTION
Closes #255

## 変更内容

- `solve-issue.sh` にロック取得（flock）と `in-progress-by-claude` ラベル管理を追加
- `watch-queued-issues.sh` から重複するロック・ラベル管理処理を除去

## 詳細

### solve-issue.sh の変更

- `LOCK_DIR` と `lock_file` を定義し、flock でロックを取得
- ロック失敗時は適切なエラーメッセージを出力して exit 1
- 処理前に `in-progress-by-claude` ラベルを付与
- `trap EXIT` で処理完了後（成否問わず）にラベルを除去

### watch-queued-issues.sh の変更

- flock による二重ロック処理を除去
- `in-progress-by-claude` ラベルの付与・除去処理を削除（solve-issue.sh に委譲）
- `WORKSPACE_DIR` / `LOCK_DIR` の定義を削除（不要になったため）

## 期待する動作

| 呼び出し方 | ロック | ラベル管理 |
|-----------|--------|----------|
| `watch-queued-issues.sh` 経由 | ✅ 機能する | ✅ 機能する |
| `solve-issue.sh` 単体 | ✅ 機能する | ✅ 機能する |

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * GitHub Issues の処理中の競合を防ぐためのロック機構を強化しました
  * Issue 処理状態のラベル管理の信頼性を向上させました

* **改善**
  * 自動化スクリプトの処理フローを最適化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->