### PR TITLE
refactor(#256): claude-stream.shラッパーを追加してstream-jsonロジックを共通化

### DIFF
--- a/.claude/scripts/assign-issues.sh
+++ b/.claude/scripts/assign-issues.sh
@@ -30,14 +30,12 @@ if [ "$ASSIGNABLE_COUNT" -eq 0 ]; then
   exit 0
 fi
 
+SCRIPT_DIR=$(dirname "$0")
+
 # Claudeでissueを選定・ラベル付与（コード変更不要のため--worktreeは不使用）
 SKILL_ARGS="/assign-issues ${ASSIGN_COUNT}"
 if "${USE_PRINT_MODE}"; then
-  claude --dangerously-skip-permissions \
-    -p "$SKILL_ARGS" \
-    --output-format stream-json --verbose --include-partial-messages | \
-    jq -rj 'if .type == "stream_event" and .event.delta.type? == "text_delta" then .event.delta.text elif .type == "result" then .result else empty end'
-  echo
+  "$SCRIPT_DIR/claude-stream.sh" --dangerously-skip-permissions -p "$SKILL_ARGS"
 else
   claude --dangerously-skip-permissions "$SKILL_ARGS"
 fi

--- a/.claude/scripts/claude-stream.sh
+++ b/.claude/scripts/claude-stream.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# claude-stream.sh - stream-json形式でClaudeを呼び出すラッパースクリプト
+#
+# 使い方: claude-stream.sh [claudeのオプション/プロンプト]
+#
+# --output-format stream-json --verbose --include-partial-messages を付与して
+# Claudeを呼び出し、jqでテキストデルタとresultのみを表示する。
+
+claude "$@" \
+  --output-format stream-json --verbose --include-partial-messages | \
+  jq -rj 'if .type == "stream_event" and .event.delta.type? == "text_delta" then .event.delta.text elif .type == "result" then .result else empty end'
+echo

--- a/.claude/scripts/solve-issue.sh
+++ b/.claude/scripts/solve-issue.sh
@@ -54,7 +54,7 @@ git pull origin main
 
 # Claudeでissueを解決（--worktreeで自動的にブランチとワークツリーを作成）
 if "${USE_PRINT_MODE}"; then
-  claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions -p "/solve-issue ${ISSUE_NUMBER}"
+  "$SCRIPT_DIR/claude-stream.sh" --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions -p "/solve-issue ${ISSUE_NUMBER}"
 else
   claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions "/solve-issue ${ISSUE_NUMBER}"
 fi


### PR DESCRIPTION
Closes #256

Claude呼び出し時のstream-jsonフィルタロジックを共通化するラッパースクリプト `.claude/scripts/claude-stream.sh` を追加し、`solve-issue.sh` と `assign-issues.sh` で共通利用するよう修正しました。

## 変更内容

- `.claude/scripts/claude-stream.sh` を新規追加
  - `--output-format stream-json --verbose --include-partial-messages` を付与してClaudeを呼び出す
  - `jq` でテキストデルタとresultのみを表示する
- `solve-issue.sh`: print modeで `claude-stream.sh` を使用するよう修正（途中経過がリアルタイム表示されるようになる）
- `assign-issues.sh`: print modeで `claude-stream.sh` を使用するよう修正（重複ロジックを削除）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このリリースには、ユーザーに直接影響を与える変更はありません。内部開発スクリプトの構造最適化と機能統合が実施されました。

* **チューア**
  * 内部スクリプトの出力処理パイプラインを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->