### PR TITLE
docs: カメラ撮影スケジュール＆テスト撮影機能の仕様書を追加

### DIFF
--- a/docs/draft/camera-capture-schedule.md
+++ b/docs/draft/camera-capture-schedule.md
@@ -20,17 +20,17 @@
 | テスト写真アップロード | `POST /api/test-photo` | script_key | ファイル保存＋camera更新＋フラグクリア |
 | スケジュール写真アップロード | `POST /api/scheduled-photo` | script_key | script_key→camera→book解決＋写真保存＋`last_scheduled_capture_at`更新 |
 | テスト写真表示 | `GET /cameras/{id}/test-photo` | cookie（requireLogin） | ファイルをサーブ |
-| 設定取得（スクリプト用） | `GET /api/script-config` | script_key | `should_test_capture`, `should_schedule_capture` を追加（`upload_key`は削除） |
+| 設定取得（スクリプト用） | `GET /api/script-config` | script_key | `should_test_capture`, `should_schedule_capture` を追加（`upload_key`は移行期間中は維持し、全スクリプト移行後に廃止） |
 | （既存）写真アップロード | `POST /api/photos` | upload_key | 既存のまま維持（後方互換） |
 
 ## スクリプトフロー
 
-```
+```text
 [cron 5分おき] ./capture_auto.sh --api-url ... --script-key ...
 
   GET /api/script-config
-    → { should_test_capture, should_schedule_capture, ... }
-    ※ upload_key は不要のため削除
+    → { should_test_capture, should_schedule_capture, upload_key, ... }
+    ※ upload_key は後方互換のため移行期間中は引き続き返却
 
   if should_test_capture == false AND should_schedule_capture == false:
     exit 0（何もしない）
@@ -77,20 +77,29 @@ ALTER TABLE cameras ADD COLUMN last_scheduled_capture_at DATETIME;  -- UTC、重
 
 ### GET /api/script-config
 
-既存フィールドから `upload_key` を削除し、以下を追加：
+既存フィールドに `should_test_capture` / `should_schedule_capture` を追加する。`upload_key` は既存スクリプト互換のため移行期間中は返却を継続し、全スクリプト移行後に削除する（廃止予定日を別途定義）。
 
 ```json
 {
   "target_brightness": 0.475,
   "brightness_tolerance": 0.175,
   "max_adjust_retries": 5,
+  "upload_key": "<key>",
   "should_test_capture": false,
   "should_schedule_capture": false
 }
 ```
 
 `should_test_capture` と `should_schedule_capture` は独立したbool値。
-`should_capture` は冗長なため提供しない（スクリプト側でOR演算して使用）。
+
+#### upload_key の移行方針
+
+- **移行期間中**: `GET /api/script-config` は `upload_key` を引き続き返却する。`scripts/capture_auto.sh` は `upload_key` を使った既存の `POST /api/photos` を継続利用可。
+- **切替条件**: 全カメラのスクリプトが `script_key` 認証による新エンドポイント（`POST /api/scheduled-photo`）に移行完了した後。
+- **廃止**: 切替完了後、`upload_key` フィールドをレスポンスから削除する（廃止予定日はスクリプト移行完了時点で別途決定）。
+- **ロールバック**: 廃止前であれば `upload_key` を再度有効化することで即時ロールバック可能。
+
+`should_capture` という統合フラグは提供しない。スクリプトはサーバーが返す `should_test_capture` と `should_schedule_capture` をそれぞれ参照して動作を決定する（判定ロジックはサーバー側のみ）。
 
 #### should_schedule_capture の判定ロジック
 
@@ -155,7 +164,7 @@ ALTER TABLE cameras ADD COLUMN last_scheduled_capture_at DATETIME;  -- UTC、重
 
 #### 撮影スケジュールセクション（輝度設定の下に追加）
 
-```
+```text
 撮影スケジュール
 ┌──────────────────────────────────────────────────┐
 │ 撮影時刻（JST）                                  │


### PR DESCRIPTION
## Summary

- カメラ設定画面からテスト撮影を行うための仕様書を `docs/draft/camera-capture-schedule.md` に追加
- ポーリング方式（cronで5分おき）のアーキテクチャを採用
- テスト撮影とスケジュール撮影でエンドポイント・保存先を分離する設計

## 主な仕様

- `PATCH /cameras/{id}` でテストモードを有効化（ブラウザ側）
- `POST /api/test-photo` でテスト写真をアップロード（スクリプト側、script_key認証）
- `POST /api/scheduled-photo` でスケジュール写真をアップロード（スクリプト側、script_key認証）
- 撮影時刻はJST入力・UTC保存
- 将来的な「N分おき」スケジュール対応も考慮した設計

## Test plan

- [ ] ドキュメントの内容を確認
- [ ] 仕様の抜け・漏れがないかレビュー

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * カメラのテスト撮影とスケジュール撮影の仕様書を追加しました。定期的に構成を取得して撮影を行う制御フロー、撮影タイミング判定ロジック、認証の扱いの違い、撮影履歴管理について記載しています。カメラ設定画面で複数時刻（JST入力／保存時にUTC変換）を設定できる機能と、テスト撮影リクエストおよび最新テスト写真の表示についても説明を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->