### PR TITLE
fix(#248): watch-empty-queue.sh のデフォルト値を変更する（ASSIGN_COUNT=1、MIN_QUEUE=1）

### DIFF
--- a/.claude/scripts/watch-empty-queue.sh
+++ b/.claude/scripts/watch-empty-queue.sh
@@ -5,8 +5,8 @@ INTERVAL_SECONDS=60
 waiting=false
 
 # デフォルト値
-ASSIGN_COUNT=2
-MIN_QUEUE=0
+ASSIGN_COUNT=1
+MIN_QUEUE=1
 
 # 引数解析
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Closes #248

watch-empty-queue.sh のデフォルト値を変更する。

- `ASSIGN_COUNT`: 2 → 1
- `MIN_QUEUE`: 0 → 1

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他の変更**
  * キューモニタリングのデフォルト動作を調整しました。キューが空と判定される条件とデフォルト割り当て数のパラメータが変更されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->