### PR TITLE
fix(#302): fix-prスキルのステップ3bから再レビュー依頼コメント投稿を削除する

### DIFF
--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -164,7 +164,7 @@ git commit -m "fix: CodeRabbitの指摘を修正"
 git push origin HEAD
 ```
 
-#### 4. 返信・再レビュー依頼
+#### 4. 返信
 
 修正をプッシュ後、上記（手順1）で取得した各レビューコメントのスレッドに返信する。
 
@@ -180,15 +180,6 @@ git push origin HEAD
 # 各コメントに対してループで実行する
 gh api repos/<OWNER>/<REPO>/pulls/comments/<COMMENT_ID>/replies \
   -X POST -f body="@coderabbitai 修正しました。ご確認ください。
-
----
-🤖 Generated with [Claude Code](https://claude.ai/claude-code)"
-```
-
-返信後、CodeRabbitに再レビューを依頼する:
-
-```bash
-gh pr comment --repo <REPO> <PR番号> --body "@coderabbitai review
 
 ---
 🤖 Generated with [Claude Code](https://claude.ai/claude-code)"


### PR DESCRIPTION
Closes #302

fix-prスキルのステップ3bから`@coderabbitai review`コメント投稿を削除する。

新しいコミットをプッシュすると CodeRabbit が自動的に再レビューを実施するため、明示的な再レビュー依頼コメントは不要。不要なコメント投稿はPRのノイズになるため削除した。

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * CodeRabbitレビュープロセスの説明を簡素化しました。コメント返信後、ワークフローが直接最初のステップに戻るよう変更され、別途の再レビュー依頼ステップが削除されました。
  * プロセス変更を反映するため、ドキュメントのセクション見出しを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->