### PR TITLE
fix(#343): solve-issueスキルのステップ6完了後の自動継続を明示化する

### DIFF
--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -147,6 +147,7 @@ GitHub Issue $ARGUMENTS を対応します。
 6. `base-tools:monologue` を実行してから、`commit-commands:commit-push-pr` スキルでPRを作成する
   - PR本文に必ず `Closes #$ARGUMENTS` を含めること（マージ時にIssueが自動クローズされる）
   - `commit-commands:commit-push-pr` スキルへPR本文を渡す際は `--body "Closes #$ARGUMENTS\n\n{説明}"` のように明示すること
+  - **重要**: `commit-commands:commit-push-pr` スキルのプロンプトが展開されたら、必ずそのワークフローを最後まで実行すること。ユーザーからの割り込みがあっても、スキルの実行を完了させてから対応すること
   - 完了後（PR作成成功・PR URLが返ってきた場合）: **ユーザーの指示を待たずに** ステップ7へ進む
 7. `base-tools:monologue` を実行してから、ローカルの `fix-pr` スキル（`.claude/skills/fix-pr/`）でCI待機・レビュー対応・マージを行う
   - **必ず `base-tools:fix-pr` ではなくローカルの `fix-pr` スキルを使うこと**（CodeRabbitのrate limit処理が含まれているため）


### PR DESCRIPTION
Closes #343

## 変更内容

`.claude/skills/solve-issue/SKILL.md` のステップ6に `**重要**` 注記を追加した。

ステップ2（`/tdd`）やステップ3（`/review`）と同様に、`commit-commands:commit-push-pr` スキルのプロンプトが展開された後もワークフローを最後まで実行し、ユーザーの割り込みがあってもスキル完了を優先するよう明示化した。

## 背景

Issue #305 の対応中にステップ6（`commit-commands:commit-push-pr`）完了後にClaudeがユーザーの確認待ち状態になる事象が発生した。本変更により同様の停止を防ぐ。

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * `solve-issue` ワークフローのステップ6（PR作成）における運用ルールを明確化しました。プロンプト展開後、ユーザーからの割り込みがあった場合でも、当該ワークフローを最後まで完了させてから割り込み対応を行うよう明記されました。既存の「完了後はステップ7へ自動進行」という動作は変わりません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->