### PR TITLE
fix(#361): solve-issue/SKILL.md のステップ7ラベルを fix-pr-local に統一する

### DIFF
--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -19,7 +19,7 @@ GitHub Issue $ARGUMENTS を対応します。
 - [ ] ステップ4：lint/format
 - [ ] ステップ5：重複チェック
 - [ ] ステップ6：PR作成
-- [ ] ステップ7：fix-pr（ローカルスキル使用）
+- [ ] ステップ7：fix-pr-local（ローカルスキル使用）
 - [ ] ステップ8：振り返り（retro）
 - [ ] ステップ9：全作業完了通知（monologue）
 
@@ -96,7 +96,7 @@ GitHub Issue $ARGUMENTS を対応します。
 | 4. lint/format | 追記 | 指摘の有無と修正内容 |
 | 5. 重複チェック | 条件付き | 既存PRが見つかった場合のみ記録 |
 | 6. PR作成 | 追記 | PR番号とURL |
-| 7. fix-pr | 追記 | CI待機・レビュー対応・マージの結果 |
+| 7. fix-pr-local | 追記 | CI待機・レビュー対応・マージの結果 |
 | 8. 振り返り | 追記 | 作成したIssue番号（あれば） |
 | 9. 全作業完了通知 | なし | monologueのみ実行 |
 
@@ -111,7 +111,7 @@ GitHub Issue $ARGUMENTS を対応します。
   - コミットがある場合は、さらにopen状態のPRが存在するか確認する
     - `gh pr list --head "worktree-issue-$ARGUMENTS" --state open --json number --jq 'length'` で件数を確認する
   - 確認結果に応じて以下のように分岐する:
-    - **既存コミットあり + open PRあり** → **「セッション再開時のメモ補完ルール」を実施してから**ステップ2〜6をスキップしてステップ7（fix-pr）へ進む
+    - **既存コミットあり + open PRあり** → **「セッション再開時のメモ補完ルール」を実施してから**ステップ2〜6をスキップしてステップ7（fix-pr-local）へ進む
     - **既存コミットあり + PRなし** → **「セッション再開時のメモ補完ルール」を実施してから**ステップ2〜4をスキップしてステップ5（重複チェック）へ進む
     - **既存コミットなし** → 通常通りステップ2（実装）へ進む
 2. `base-tools:monologue` を実行してから、実装する
@@ -139,7 +139,7 @@ GitHub Issue $ARGUMENTS を対応します。
     1. **merged状態のPRが存在する場合**: 既に対応済みのため、以下の手順でIssueをクローズし、処理をスキップして完了する（ステップ8の振り返りのみ実施する）
        - merged PRの情報を取得: `gh pr list --search "#{番号}" --state merged --json number,url --jq '.[0]'`
        - Issueをコメント付きでクローズ: `gh issue close {番号} --comment "対応済みPR #{PR番号} が既にマージされているためクローズします。\n\nPR: {PR URL}"`
-    2. **open状態のPRが存在する場合**: 新しいPRを作成せず、既存PRに対してステップ7（fix-pr）を継続する
+    2. **open状態のPRが存在する場合**: 新しいPRを作成せず、既存PRに対してステップ7（fix-pr-local）を継続する
        - 複数のopen PRがある場合は、最新のものを対象とする
        - PR番号の取得例: `gh pr list --head "worktree-issue-{番号}" --state open --json number --jq '.[0].number'`
     3. **closed状態（マージされずにクローズ）のPRのみ存在する場合**: 既存PRなしとして扱い、ステップ6に進む


### PR DESCRIPTION
Closes #361

## 変更内容

`.claude/skills/solve-issue/SKILL.md` の4箇所で古いスキル名 `fix-pr` を `fix-pr-local` に統一しました。

| 行 | 変更内容 |
|---|---|
| 22 | チェックリストのステップ7ラベル |
| 99 | 記録粒度テーブルのステップ7 |
| 114 | セッション再開時の分岐ロジック |
| 142 | 重複チェックの分岐ロジック |

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * ワークフロー定義内の命名規則とルーティングロジックを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->