### PR TITLE
feat(#313): quality-check/tddスキルのlint/formatチェックにファイル種別スキップ条件を追加する

### DIFF
--- a/.claude/skills/quality-check/SKILL.md
+++ b/.claude/skills/quality-check/SKILL.md
@@ -28,10 +28,16 @@ argument-hint: "[target-commit-or-pr]"
    ```
 
 2. **linterチェック（自動）**
-   ```bash
-   golangci-lint run
-   find scripts .claude -type f -name '*.sh' -print0 | xargs -0 shellcheck
-   ```
+   - Goファイルの変更がある場合のみ実行:
+     ```bash
+     gofmt -l .  # 出力があれば gofmt -w . で修正
+     golangci-lint run
+     ```
+   - `.sh` ファイルの変更がある場合のみ実行:
+     ```bash
+     find scripts .claude -type f -name '*.sh' -print0 | xargs -0 shellcheck
+     ```
+   - 変更ファイルがMarkdownのみの場合: このステップをスキップ
 
 3. **テスト実行**
    ```bash

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -57,7 +57,7 @@ argument-hint: "[task-description]"
 
 1. テストが通ったまま、コードの重複を除去・整理する
 2. `go test ./...` でテストがPASSしたままであることを確認する
-3. `golangci-lint run` でlintエラーがないことを確認する
+3. Goファイルの変更がある場合のみ `golangci-lint run` でlintエラーがないことを確認する
 
 **制約**: Refactor中はテストコードを変更しない
 
@@ -74,10 +74,19 @@ argument-hint: "[task-description]"
 ```bash
 # 全テストを実行（レースコンディション検出）
 go test -v -race ./...
-
-# lintチェック
-golangci-lint run
 ```
+
+- Goファイルの変更がある場合のみ実行:
+  ```bash
+  # lintチェック
+  gofmt -l .  # 出力があれば gofmt -w . で修正
+  golangci-lint run
+  ```
+- `.sh` ファイルの変更がある場合のみ実行:
+  ```bash
+  find scripts .claude -type f -name '*.sh' -print0 | xargs -0 shellcheck
+  ```
+- 変更ファイルがMarkdownのみの場合: lint/formatチェックはスキップ
 
 ## 制約まとめ
 


### PR DESCRIPTION
Closes #313

quality-checkとtddスキルのlint/formatチェックに、solve-issueスキルのステップ4と同様のファイル種別によるスキップ条件を追加します。

## 変更内容

### `.claude/skills/quality-check/SKILL.md`
- ステップ2（linterチェック）にファイル種別スキップ条件を追加
  - Goファイルの変更がある場合のみ `gofmt` / `golangci-lint` を実行
  - `.sh` ファイルの変更がある場合のみ `shellcheck` を実行
  - 変更ファイルがMarkdownのみの場合はスキップ

### `.claude/skills/tdd/SKILL.md`
- Refactorフェーズ: `golangci-lint run` にGoファイル変更時のみ実行する条件を追加
- Phase 3（完了確認）: `gofmt` / `golangci-lint` / `shellcheck` にスキップ条件を追加

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CD パイプラインを最適化しました。リント・フォーマットチェックがファイル変更の種類に応じて条件付きで実行されるようになり、不要な検査の実行が削減されました。Go ファイルの変更時にはフォーマット確認が実行され、シェルスクリプト変更時には構文チェックが行われます。Markdown のみの変更時はこれらのチェックはスキップされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->